### PR TITLE
Fix/spread calc

### DIFF
--- a/src/components/createPool/BuyModal.tsx
+++ b/src/components/createPool/BuyModal.tsx
@@ -71,10 +71,13 @@ export default function BuyModal({ isOpen, onDismiss, poolInfo, userBaseTokenBal
     // price plus spread
     const poolAmount = JSBI.divide(
       JSBI.multiply(
-        JSBI.subtract(parsedAmount.quotient, JSBI.divide(parsedAmount.quotient, JSBI.BigInt(20))), //parsedAmount.quotient,
+        JSBI.subtract(
+          parsedAmount.quotient,
+          JSBI.divide(JSBI.multiply(parsedAmount.quotient, JSBI.BigInt(poolInfo.spread)), JSBI.BigInt(10000))
+        ),
         JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(parsedAmount.currency.decimals ?? 18))
       ),
-      poolInfo.poolPriceAmount.quotient //: JSBI.BigInt(1)
+      poolInfo.poolPriceAmount.quotient
     )
     // extra 2% margin
     const minimumAmount = JSBI.subtract(poolAmount, JSBI.divide(poolAmount, JSBI.BigInt(50)))

--- a/src/components/createPool/SellModal.tsx
+++ b/src/components/createPool/SellModal.tsx
@@ -70,7 +70,10 @@ export default function SellModal({ isOpen, onDismiss, poolInfo, userBaseTokenBa
     // price plus spread
     const baseTokenAmount = JSBI.divide(
       JSBI.multiply(
-        JSBI.subtract(parsedAmount.quotient, JSBI.divide(parsedAmount.quotient, JSBI.BigInt(20))),
+        JSBI.subtract(
+          parsedAmount.quotient,
+          JSBI.divide(JSBI.multiply(parsedAmount.quotient, JSBI.BigInt(poolInfo.spread)), JSBI.BigInt(10000))
+        ),
         poolInfo.poolPriceAmount.quotient
       ),
       JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(parsedAmount.currency.decimals ?? 18))

--- a/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/src/pages/CreatePool/PoolPositionPage.tsx
@@ -275,7 +275,7 @@ export function PoolPositionPage() {
   // TODO: check if should move definitions in custom hook
   //const poolInfo= usePoolInfo(poolAddressFromUrl)
   // TODO: pass recipient as optional parameter to check currency balance hook
-  const poolInfo = { pool, recipient: account, userPoolBalance, poolPriceAmount: poolPrice } as PoolInfo
+  const poolInfo = { pool, recipient: account, userPoolBalance, poolPriceAmount: poolPrice, spread } as PoolInfo
   const userBaseTokenBalance = useCurrencyBalance(account ?? undefined, base ?? undefined)
   const toggleWalletModal = useToggleWalletModal()
 

--- a/src/state/buy/hooks.tsx
+++ b/src/state/buy/hooks.tsx
@@ -14,7 +14,7 @@ export interface PoolInfo {
   // the total amount of pool tokens held by the account
   userPoolBalance: CurrencyAmount<Token>
   poolPriceAmount: CurrencyAmount<Token>
-  spread?: number
+  spread: number
 }
 
 // based on typed value


### PR DESCRIPTION
This PR uses the actual spread for calculating expected returned amount in buy and sell modals, instead of the 5% placeholder we used before. The calculations will reflect actual pool spread, which may be updated by the pool operators.