### PR TITLE
fix: update selected pool in operated pools dropdown list

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -296,6 +296,7 @@ export default function Swap() {
 
   // swap state
   const { independentField, typedValue, recipient, smartPoolAddress, smartPoolName } = useSwapState()
+  const smartPool = useCurrency(smartPoolAddress)
   const {
     trade: { state: tradeState, trade },
     allowedSlippage,
@@ -665,7 +666,7 @@ export default function Swap() {
                 isOpen={modalOpen}
                 onDismiss={handleDismissSearch}
                 onCurrencySelect={onPoolSelection}
-                selectedCurrency={defaultPool}
+                selectedCurrency={smartPool}
                 operatedPools={operatedPools}
                 showCommonBases={false}
                 showCurrencyAmount={false}


### PR DESCRIPTION
This PR updates the selected pool in the operated pools dropdown as pool operator switches from one pool to another
