### PR TITLE
Fix/order by apr

### DIFF
--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -50,6 +50,10 @@ const MobileHeader = styled.div`
   }
 `
 
+function highestAprFirst(a: any, b: any) {
+  return b.apr - a.apr
+}
+
 type PoolPositionListProps = React.PropsWithChildren<{
   positions: PoolPositionDetails[]
   filterByOperator?: any
@@ -106,10 +110,10 @@ export default function PoolPositionList({ positions, filterByOperator, filterBy
         <div>{!filterByOperator && <Trans>apr</Trans>}</div>
       </MobileHeader>
       {operatedPools.length !== 0 ? (
-        operatedPools.map((p: any) => {
+        operatedPools.sort(highestAprFirst).map((p: any) => {
           return (
             <PoolPositionListItem
-              key={p?.name.toString()}
+              key={p?.address.toString()}
               positionDetails={p}
               returnPage={filterByOperator ? 'mint' : 'stake'}
             />

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -85,6 +85,7 @@ export default function Stake() {
 
   // TODO: return loading
   const allPools = useRegisteredPools()
+  // TODO: order all pools by apr
   const loadingPools = false
 
   //const [activeFilters, filtersDispatch] = useReducer(reduceFilters, initialFilterState)

--- a/src/state/pool/hooks.ts
+++ b/src/state/pool/hooks.ts
@@ -366,7 +366,7 @@ export function useStakingPools(addresses: string[] | undefined, poolIds: string
         const result = call.result as CallStateResult
         return {
           id,
-          poolOwnStake: result[0].currentEpochBalance,
+          poolOwnStake: result[0].nextEpochBalance,
         }
       })
     }


### PR DESCRIPTION
This PR sorts displayed pools by apr and updates pool apr when pool stakes to self

- order displayed pools by apr
- use currentEpochBalance to compute pool own stake ratio, updating apr in real time when pool stakes
- added TODO comment as we want to order all pools by apr and then display the already sorted ones in staking, while currently we only sort the pools displayed by infinite scroll
- use address instead of name for unique pool list mapping
