### PR TITLE
fix: switch button disable assertion

### DIFF
--- a/src/components/earn/MoveStakeModal.tsx
+++ b/src/components/earn/MoveStakeModal.tsx
@@ -183,9 +183,7 @@ export default function MoveStakeModal({ isOpen, poolInfo, onDismiss, title }: M
             </LightCard>
             <ButtonPrimary
               disabled={
-                !fromPoolStakeBalance ||
-                formatCurrencyAmount(parsedAmount, 4) === '0' ||
-                (fromPoolId !== defaultPoolId && !isAddress(parsedAddress ?? ''))
+                formatCurrencyAmount(parsedAmount, 4) === '0' || (typed !== '' && !isAddress(parsedAddress ?? ''))
               }
               onClick={onMoveStake}
             >

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -414,7 +414,10 @@ export function useUserVotesAsOfBlock(block: number | undefined): CurrencyAmount
   return votes && uni ? CurrencyAmount.fromRawAmount(uni, votes) : undefined
 }
 
-export function usePoolIdByAddress(pool: string | undefined): { poolId: string; stakingPoolExists: boolean } {
+export function usePoolIdByAddress(pool: string | undefined): {
+  poolId: string | undefined
+  stakingPoolExists: boolean
+} {
   const registryContract = useRegistryContract()
   const poolId = useSingleCallResult(registryContract ?? undefined, 'getPoolIdFromAddress', [pool ?? undefined])
     ?.result?.[0]


### PR DESCRIPTION
This PR fissues an issue which does not pass switch button activation validation when params are correct when using a deprecated pool

- remove fromPoolStakeBalance exists assertion as later checked in onMoveStake
- fixed typed input isAddress when user types instead of asserting by fromPoolId and defaultPoolId, which are always different by definition