### PR TITLE
fix: pass correct values to move stake hook from parent

### DIFF
--- a/src/components/earn/MoveStakeModal.tsx
+++ b/src/components/earn/MoveStakeModal.tsx
@@ -94,8 +94,8 @@ export default function MoveStakeModal({ isOpen, poolInfo, onDismiss, title }: M
 
   const moveStakeData = {
     amount: parsedAmount?.quotient.toString(),
-    pool: parsedAddress,
-    fromPoolId,
+    pool: poolInfo.pool?.address,
+    fromPoolId: fromPoolId ?? defaultPoolId,
     poolId,
     poolContract: undefined,
     stakingPoolExists,


### PR DESCRIPTION
This PR passes correct parameters to stakeData tuple when switching from deprecated staking pool