### PR TITLE
fix: stake/move stake transaction submitted amount

### DIFF
--- a/src/components/earn/MoveStakeModal.tsx
+++ b/src/components/earn/MoveStakeModal.tsx
@@ -106,6 +106,7 @@ export default function MoveStakeModal({ isOpen, poolInfo, onDismiss, title }: M
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()
   const [attempting, setAttempting] = useState(false)
+  const [stakeAmount, setStakeAmount] = useState<CurrencyAmount<Currency>>()
 
   // wrapper to reset state on modal close
   function wrappedOnDismiss() {
@@ -120,6 +121,7 @@ export default function MoveStakeModal({ isOpen, poolInfo, onDismiss, title }: M
 
   async function onMoveStake() {
     setAttempting(true)
+    setStakeAmount(parsedAmount)
 
     // if callback not returned properly ignore
     if (!moveStakeCallback || !fromPoolStakeBalance || !moveStakeData || !currencyValue.isToken) return
@@ -210,7 +212,7 @@ export default function MoveStakeModal({ isOpen, poolInfo, onDismiss, title }: M
             <ThemedText.DeprecatedLargeHeader>
               <Trans>Transaction Submitted</Trans>
             </ThemedText.DeprecatedLargeHeader>
-            <ThemedText.DeprecatedMain fontSize={36}>{formatCurrencyAmount(parsedAmount, 4)}</ThemedText.DeprecatedMain>
+            <ThemedText.DeprecatedMain fontSize={36}>{formatCurrencyAmount(stakeAmount, 4)}</ThemedText.DeprecatedMain>
           </AutoColumn>
         </SubmittedView>
       )}

--- a/src/components/vote/DelegateModal.tsx
+++ b/src/components/vote/DelegateModal.tsx
@@ -116,6 +116,7 @@ export default function DelegateModal({ isOpen, poolInfo, onDismiss, title }: Vo
   // monitor call to help UI loading state
   const [hash, setHash] = useState<string | undefined>()
   const [attempting, setAttempting] = useState(false)
+  const [stakeAmount, setStakeAmount] = useState<CurrencyAmount<Currency>>()
 
   // wrapper to reset state on modal close
   function wrappedOnDismiss() {
@@ -130,6 +131,7 @@ export default function DelegateModal({ isOpen, poolInfo, onDismiss, title }: Vo
 
   async function onDelegate() {
     setAttempting(true)
+    setStakeAmount(parsedAmount)
 
     // if callback not returned properly ignore
     if (!delegateCallback || !grgBalance || !stakeData || !currencyValue.isToken) return
@@ -250,7 +252,7 @@ export default function DelegateModal({ isOpen, poolInfo, onDismiss, title }: Vo
             <ThemedText.DeprecatedLargeHeader>
               <Trans>Transaction Submitted</Trans>
             </ThemedText.DeprecatedLargeHeader>
-            <ThemedText.DeprecatedMain fontSize={36}>{formatCurrencyAmount(parsedAmount, 4)}</ThemedText.DeprecatedMain>
+            <ThemedText.DeprecatedMain fontSize={36}>{formatCurrencyAmount(stakeAmount, 4)}</ThemedText.DeprecatedMain>
           </AutoColumn>
         </SubmittedView>
       )}


### PR DESCRIPTION
This PR fixes the returned amount  in stake and move stake transaction submitted in order to prevent amount calculated as % of balance to be changed when transaction is confirmed onchain and balance changed.

- always return correct amount in stake transaction submitted modals
- do not query amount from balance, but from new storage variable
