### PR TITLE
feat: bnb historical pools

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -10,7 +10,7 @@ REACT_APP_FIREBASE_KEY="AIzaSyBcZWwTcTJHj_R6ipZcrJkXdq05PuX0Rs0"
 REACT_APP_MOONPAY_API="https://api.moonpay.com"
 REACT_APP_MOONPAY_LINK="https://us-central1-uniswap-mobile.cloudfunctions.net/signMoonpayLinkV2?platform=web&env=production"
 REACT_APP_MOONPAY_PUBLISHABLE_KEY="pk_live_uQG4BJC4w3cxnqpcSqAfohdBFDTsY6E"
-REACT_APP_SENTRY_ENABLED=true
+REACT_APP_SENTRY_ENABLED=false
 REACT_APP_SENTRY_TRACES_SAMPLE_RATE=0.00003
 REACT_APP_STATSIG_PROXY_URL="https://api.uniswap.org/v1/statsig-proxy"
 THE_GRAPH_SCHEMA_ENDPOINT="https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3"

--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -2,6 +2,8 @@ export const UNI_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
 export const UNI_EXTENDED_LIST = 'https://gateway.ipfs.io/ipns/extendedtokens.uniswap.org'
 const UNI_UNSUPPORTED_LIST = 'https://gateway.ipfs.io/ipns/unsupportedtokens.uniswap.org'
 export const RB_LIST = 'https://tokens.rigoblock.com'
+// pools list is returned separately from token lists
+const RB_POOLS_LIST = 'https://pools.rigoblock.com'
 const AAVE_LIST = 'tokenlist.aave.eth'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
 // TODO(INFRA-179): Re-enable CMC list once we have a better solution for handling large lists.
@@ -50,3 +52,4 @@ export const DEFAULT_INACTIVE_LIST_URLS: string[] = [
 ]
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [...DEFAULT_ACTIVE_LIST_URLS, ...DEFAULT_INACTIVE_LIST_URLS]
+export const POOLS_LIST: string[] = [RB_POOLS_LIST]

--- a/src/serviceWorker/document.ts
+++ b/src/serviceWorker/document.ts
@@ -1,4 +1,4 @@
-import { isAppUniswapOrg, isAppUniswapStagingOrg } from 'utils/env'
+import { isAppRigoblockCom, isAppRigoblockStagingCom } from 'utils/env'
 import { RouteHandlerCallbackOptions, RouteMatchCallbackOptions } from 'workbox-core'
 import { getCacheKeyForURL, matchPrecache } from 'workbox-precaching'
 import { Route } from 'workbox-routing'
@@ -25,7 +25,7 @@ export function matchDocument({ request, url }: RouteMatchCallbackOptions) {
 
   // If this isn't app.uniswap.org (or a local build), skip.
   // IPFS gateways may not have domain separation, so they cannot use document caching.
-  if (!(isDevelopment() || isAppUniswapStagingOrg(url) || isAppUniswapOrg(url))) {
+  if (!(isDevelopment() || isAppRigoblockStagingCom(url) || isAppRigoblockCom(url))) {
     return false
   }
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -8,7 +8,7 @@ import { sentryEnhancer } from './logging'
 import reducer from './reducer'
 import { routingApi } from './routing/slice'
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'poolslist']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'poolsList']
 
 const store = configureStore({
   reducer,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -8,7 +8,7 @@ import { sentryEnhancer } from './logging'
 import reducer from './reducer'
 import { routingApi } from './routing/slice'
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'poolslist']
 
 const store = configureStore({
   reducer,

--- a/src/state/lists/poolsList/actions.ts
+++ b/src/state/lists/poolsList/actions.ts
@@ -6,13 +6,13 @@ export const fetchTokenList: Readonly<{
   fulfilled: ActionCreatorWithPayload<{ url: string; tokenList: TokenList; requestId: string }>
   rejected: ActionCreatorWithPayload<{ url: string; errorMessage: string; requestId: string }>
 }> = {
-  pending: createAction('poolslist/fetchTokenList/pending'),
-  fulfilled: createAction('poolslist/fetchTokenList/fulfilled'),
-  rejected: createAction('poolslist/fetchTokenList/rejected'),
+  pending: createAction('poolsList/fetchTokenList/pending'),
+  fulfilled: createAction('poolsList/fetchTokenList/fulfilled'),
+  rejected: createAction('poolsList/fetchTokenList/rejected'),
 }
 // add and remove from list options
-export const addList = createAction<string>('poolslist/addList')
-export const removeList = createAction<string>('poolslist/removeList')
+export const addList = createAction<string>('poolsList/addList')
+export const removeList = createAction<string>('poolsList/removeList')
 
 // versioning
-export const acceptListUpdate = createAction<string>('poolslist/acceptListUpdate')
+export const acceptListUpdate = createAction<string>('poolsList/acceptListUpdate')

--- a/src/state/lists/poolsList/actions.ts
+++ b/src/state/lists/poolsList/actions.ts
@@ -1,0 +1,18 @@
+import { ActionCreatorWithPayload, createAction } from '@reduxjs/toolkit'
+import { TokenList } from '@uniswap/token-lists'
+
+export const fetchTokenList: Readonly<{
+  pending: ActionCreatorWithPayload<{ url: string; requestId: string }>
+  fulfilled: ActionCreatorWithPayload<{ url: string; tokenList: TokenList; requestId: string }>
+  rejected: ActionCreatorWithPayload<{ url: string; errorMessage: string; requestId: string }>
+}> = {
+  pending: createAction('poolslist/fetchTokenList/pending'),
+  fulfilled: createAction('poolslist/fetchTokenList/fulfilled'),
+  rejected: createAction('poolslist/fetchTokenList/rejected'),
+}
+// add and remove from list options
+export const addList = createAction<string>('poolslist/addList')
+export const removeList = createAction<string>('poolslist/removeList')
+
+// versioning
+export const acceptListUpdate = createAction<string>('poolslist/acceptListUpdate')

--- a/src/state/lists/poolsList/hooks.ts
+++ b/src/state/lists/poolsList/hooks.ts
@@ -9,8 +9,8 @@ type Mutable<T> = {
   -readonly [P in keyof T]: Mutable<T[P]>
 }
 
-export function usePoolsList(): AppState['poolslist']['byUrl'] {
-  return useAppSelector((state) => state.poolslist.byUrl)
+export function usePoolsList(): AppState['poolsList']['byUrl'] {
+  return useAppSelector((state) => state.poolsList.byUrl)
 }
 
 /**

--- a/src/state/lists/poolsList/hooks.ts
+++ b/src/state/lists/poolsList/hooks.ts
@@ -1,0 +1,56 @@
+import { TokenAddressMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/utils'
+import { useMemo } from 'react'
+import { useAppSelector } from 'state/hooks'
+
+import { POOLS_LIST } from '../../../constants/lists'
+import { AppState } from '../../types'
+
+type Mutable<T> = {
+  -readonly [P in keyof T]: Mutable<T[P]>
+}
+
+export function usePoolsList(): AppState['poolslist']['byUrl'] {
+  return useAppSelector((state) => state.poolslist.byUrl)
+}
+
+/**
+ * Combine the tokens in map2 with the tokens on map1, where tokens on map1 take precedence
+ * @param map1 the base token map
+ * @param map2 the map of additioanl tokens to add to the base map
+ */
+function combineMaps(map1: TokenAddressMap, map2: TokenAddressMap): TokenAddressMap {
+  const chainIds = Object.keys(
+    Object.keys(map1)
+      .concat(Object.keys(map2))
+      .reduce<{ [chainId: string]: true }>((memo, value) => {
+        memo[value] = true
+        return memo
+      }, {})
+  ).map((id) => parseInt(id))
+
+  return chainIds.reduce<Mutable<TokenAddressMap>>((memo, chainId) => {
+    memo[chainId] = {
+      ...map2[chainId],
+      // map1 takes precedence
+      ...map1[chainId],
+    }
+    return memo
+  }, {}) as TokenAddressMap
+}
+
+export function usePoolMapFromUrl(urls: string[] | undefined): TokenAddressMap {
+  const lists = usePoolsList()
+  return useMemo(() => {
+    if (!urls) return {}
+    return urls.slice().reduce((allTokens, currentUrl) => {
+      const current = lists[currentUrl]?.current
+      if (!current) return allTokens
+      try {
+        return combineMaps(allTokens, tokensToChainTokenMap(current))
+      } catch (error) {
+        console.error('Could not show token list due to error', error)
+        return allTokens
+      }
+    }, {})
+  }, [lists, urls])
+}

--- a/src/state/lists/poolsList/hooks.ts
+++ b/src/state/lists/poolsList/hooks.ts
@@ -2,7 +2,6 @@ import { TokenAddressMap, tokensToChainTokenMap } from 'lib/hooks/useTokenList/u
 import { useMemo } from 'react'
 import { useAppSelector } from 'state/hooks'
 
-import { POOLS_LIST } from '../../../constants/lists'
 import { AppState } from '../../types'
 
 type Mutable<T> = {

--- a/src/state/lists/poolsList/reducer.ts
+++ b/src/state/lists/poolsList/reducer.ts
@@ -1,0 +1,138 @@
+import { createReducer } from '@reduxjs/toolkit'
+import { getVersionUpgrade, TokenList, VersionUpgrade } from '@uniswap/token-lists'
+
+import { POOLS_LIST } from '../../../constants/lists'
+import { updateVersion } from '../../global/actions'
+import { acceptListUpdate, addList, fetchTokenList, removeList } from './actions'
+
+// TODO: check unique state
+export interface ListsState {
+  readonly byUrl: {
+    readonly [url: string]: {
+      readonly current: TokenList | null
+      readonly pendingUpdate: TokenList | null
+      readonly loadingRequestId: string | null
+      readonly error: string | null
+    }
+  }
+  // this contains the default pools list from the last time the updateVersion was called, i.e. the app was reloaded
+  readonly lastInitializedPoolsList?: string[]
+}
+
+type ListState = ListsState['byUrl'][string]
+
+const NEW_LIST_STATE: ListState = {
+  error: null,
+  current: null,
+  loadingRequestId: null,
+  pendingUpdate: null,
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] extends ReadonlyArray<infer U> ? U[] : T[P] }
+
+const initialState: ListsState = {
+  lastInitializedPoolsList: POOLS_LIST,
+  byUrl: {
+    ...POOLS_LIST.reduce<Mutable<ListsState['byUrl']>>((memo, listUrl) => {
+      memo[listUrl] = NEW_LIST_STATE
+      return memo
+    }, {}),
+  },
+}
+
+export default createReducer(initialState, (builder) =>
+  builder
+    .addCase(fetchTokenList.pending, (state, { payload: { requestId, url } }) => {
+      const current = state.byUrl[url]?.current ?? null
+      const pendingUpdate = state.byUrl[url]?.pendingUpdate ?? null
+
+      state.byUrl[url] = {
+        current,
+        pendingUpdate,
+        loadingRequestId: requestId,
+        error: null,
+      }
+    })
+    .addCase(fetchTokenList.fulfilled, (state, { payload: { requestId, tokenList, url } }) => {
+      const current = state.byUrl[url]?.current
+      const loadingRequestId = state.byUrl[url]?.loadingRequestId
+
+      // no-op if update does nothing
+      if (current) {
+        const upgradeType = getVersionUpgrade(current.version, tokenList.version)
+
+        if (upgradeType === VersionUpgrade.NONE) return
+        if (loadingRequestId === null || loadingRequestId === requestId) {
+          state.byUrl[url] = {
+            current,
+            pendingUpdate: tokenList,
+            loadingRequestId: null,
+            error: null,
+          }
+        }
+      } else {
+        state.byUrl[url] = {
+          current: tokenList,
+          pendingUpdate: null,
+          loadingRequestId: null,
+          error: null,
+        }
+      }
+    })
+    .addCase(fetchTokenList.rejected, (state, { payload: { url, requestId, errorMessage } }) => {
+      if (state.byUrl[url]?.loadingRequestId !== requestId) {
+        // no-op since it's not the latest request
+        return
+      }
+
+      state.byUrl[url] = {
+        current: state.byUrl[url].current ? state.byUrl[url].current : null,
+        pendingUpdate: null,
+        loadingRequestId: null,
+        error: errorMessage,
+      }
+    })
+    .addCase(addList, (state, { payload: url }) => {
+      if (!state.byUrl[url]) {
+        state.byUrl[url] = NEW_LIST_STATE
+      }
+    })
+    .addCase(removeList, (state, { payload: url }) => {
+      if (state.byUrl[url]) {
+        delete state.byUrl[url]
+      }
+    })
+    .addCase(acceptListUpdate, (state, { payload: url }) => {
+      if (!state.byUrl[url]?.pendingUpdate) {
+        throw new Error('accept list update called without pending update')
+      }
+      state.byUrl[url] = {
+        ...state.byUrl[url],
+        current: state.byUrl[url].pendingUpdate,
+        pendingUpdate: null,
+      }
+    })
+    .addCase(updateVersion, (state) => {
+      // state loaded from localStorage, but new lists have never been initialized
+      if (!state.lastInitializedPoolsList) {
+        state.byUrl = initialState.byUrl
+      } else if (state.lastInitializedPoolsList) {
+        const lastInitializedSet = state.lastInitializedPoolsList.reduce<Set<string>>((s, l) => s.add(l), new Set())
+        const newListOfListsSet = POOLS_LIST.reduce<Set<string>>((s, l) => s.add(l), new Set())
+
+        POOLS_LIST.forEach((listUrl) => {
+          if (!lastInitializedSet.has(listUrl)) {
+            state.byUrl[listUrl] = NEW_LIST_STATE
+          }
+        })
+
+        state.lastInitializedPoolsList.forEach((listUrl) => {
+          if (!newListOfListsSet.has(listUrl)) {
+            delete state.byUrl[listUrl]
+          }
+        })
+      }
+
+      state.lastInitializedPoolsList = POOLS_LIST
+    })
+)

--- a/src/state/lists/poolsList/updater.ts
+++ b/src/state/lists/poolsList/updater.ts
@@ -1,0 +1,71 @@
+import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
+import { useWeb3React } from '@web3-react/core'
+import { POOLS_LIST } from 'constants/lists'
+import useInterval from 'lib/hooks/useInterval'
+import ms from 'ms.macro'
+import { useCallback, useEffect } from 'react'
+import { useAppDispatch } from 'state/hooks'
+import { usePoolsList } from 'state/lists/poolsList/hooks'
+
+import { useFetchListCallback } from '../../../hooks/useFetchListCallback'
+import useIsWindowVisible from '../../../hooks/useIsWindowVisible'
+import { acceptListUpdate } from './actions'
+import { shouldAcceptVersionUpdate } from './utils'
+
+export default function Updater(): null {
+  const { provider } = useWeb3React()
+  const dispatch = useAppDispatch()
+  const isWindowVisible = useIsWindowVisible()
+
+  // get all loaded lists, and the active urls
+  const lists = usePoolsList()
+
+  const fetchList = useFetchListCallback()
+  const fetchAllListsCallback = useCallback(() => {
+    if (!isWindowVisible) return
+    POOLS_LIST.forEach((url) => {
+      // Skip validation on unsupported lists
+      const isUnsupportedList = false
+      fetchList(url, isUnsupportedList).catch((error) => console.debug('interval list fetching error', error))
+    })
+  }, [fetchList, isWindowVisible])
+
+  // fetch all lists every 10 minutes, but only after we initialize provider
+  useInterval(fetchAllListsCallback, provider ? ms`10m` : null)
+
+  // whenever a list is not loaded and not loading, try again to load it
+  useEffect(() => {
+    Object.keys(lists).forEach((listUrl) => {
+      const list = lists[listUrl]
+      if (!list.current && !list.loadingRequestId && !list.error) {
+        fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
+      }
+    })
+  }, [dispatch, fetchList, lists])
+
+  // automatically update lists if versions are minor/patch
+  useEffect(() => {
+    Object.keys(lists).forEach((listUrl) => {
+      const list = lists[listUrl]
+      if (list.current && list.pendingUpdate) {
+        const bump = getVersionUpgrade(list.current.version, list.pendingUpdate.version)
+        switch (bump) {
+          case VersionUpgrade.NONE:
+            throw new Error('unexpected no version bump')
+          case VersionUpgrade.PATCH:
+          case VersionUpgrade.MINOR: {
+            if (shouldAcceptVersionUpdate(listUrl, list.current, list.pendingUpdate, bump)) {
+              dispatch(acceptListUpdate(listUrl))
+            }
+            break
+          }
+          // update any active or inactive lists
+          case VersionUpgrade.MAJOR:
+            dispatch(acceptListUpdate(listUrl))
+        }
+      }
+    })
+  }, [dispatch, lists])
+
+  return null
+}

--- a/src/state/lists/poolsList/utils.ts
+++ b/src/state/lists/poolsList/utils.ts
@@ -1,0 +1,19 @@
+import { minVersionBump, TokenList, VersionUpgrade } from '@uniswap/token-lists'
+
+export function shouldAcceptVersionUpdate(
+  listUrl: string,
+  current: TokenList,
+  update: TokenList,
+  targetBump: VersionUpgrade.PATCH | VersionUpgrade.MINOR
+): boolean {
+  const min = minVersionBump(current.tokens, update.tokens)
+  // Automatically update minor/patch as long as bump matches the min update.
+  if (targetBump >= min) {
+    return true
+  } else {
+    console.debug(
+      `List at url ${listUrl} could not automatically update because the version bump was only PATCH/MINOR while the update had breaking changes and should have been MAJOR`
+    )
+    return false
+  }
+}

--- a/src/state/lists/poolsList/wrappedTokenInfo.ts
+++ b/src/state/lists/poolsList/wrappedTokenInfo.ts
@@ -1,0 +1,82 @@
+import { Currency, Token } from '@uniswap/sdk-core'
+import { Tags, TokenInfo, TokenList } from '@uniswap/token-lists'
+
+import { isAddress } from '../../../utils'
+
+type TagDetails = Tags[keyof Tags]
+interface TagInfo extends TagDetails {
+  id: string
+}
+/**
+ * Token instances created from token info on a token list.
+ */
+export class WrappedTokenInfo implements Token {
+  public readonly isNative = false as const
+  public readonly isToken = true as const
+  public readonly list?: TokenList
+  public readonly tokenInfo: TokenInfo
+
+  private _checksummedAddress: string
+
+  constructor(tokenInfo: TokenInfo, list?: TokenList) {
+    this.tokenInfo = tokenInfo
+    this.list = list
+    const checksummedAddress = isAddress(this.tokenInfo.address)
+    if (!checksummedAddress) {
+      throw new Error(`Invalid token address: ${this.tokenInfo.address}`)
+    }
+    this._checksummedAddress = checksummedAddress
+  }
+
+  public get address(): string {
+    return this._checksummedAddress
+  }
+
+  public get chainId(): number {
+    return this.tokenInfo.chainId
+  }
+
+  public get decimals(): number {
+    return this.tokenInfo.decimals
+  }
+
+  public get name(): string {
+    return this.tokenInfo.name
+  }
+
+  public get symbol(): string {
+    return this.tokenInfo.symbol
+  }
+
+  public get logoURI(): string | undefined {
+    return this.tokenInfo.logoURI
+  }
+
+  private _tags: TagInfo[] | null = null
+  public get tags(): TagInfo[] {
+    if (this._tags !== null) return this._tags
+    if (!this.tokenInfo.tags) return (this._tags = [])
+    const listTags = this.list?.tags
+    if (!listTags) return (this._tags = [])
+
+    return (this._tags = this.tokenInfo.tags.map((tagId) => {
+      return {
+        ...listTags[tagId],
+        id: tagId,
+      }
+    }))
+  }
+
+  equals(other: Currency): boolean {
+    return other.chainId === this.chainId && other.isToken && other.address.toLowerCase() === this.address.toLowerCase()
+  }
+
+  sortsBefore(other: Token): boolean {
+    if (this.equals(other)) throw new Error('Addresses should not be equal')
+    return this.address.toLowerCase() < other.address.toLowerCase()
+  }
+
+  public get wrapped(): Token {
+    return this
+  }
+}

--- a/src/state/pool/hooks.ts
+++ b/src/state/pool/hooks.ts
@@ -9,13 +9,17 @@ import POOL_EXTENDED_ABI from 'abis/pool-extended.json'
 import RB_POOL_FACTORY_ABI from 'abis/rb-pool-factory.json'
 import RB_REGISTRY_ABI from 'abis/rb-registry.json'
 import { RB_FACTORY_ADDRESSES, RB_REGISTRY_ADDRESSES } from 'constants/addresses'
+import { POOLS_LIST } from 'constants/lists'
 import { GRG } from 'constants/tokens'
+import { ChainTokenMap } from 'hooks/Tokens'
 import { useContract } from 'hooks/useContract'
 import { useTotalSupply } from 'hooks/useTotalSupply'
+import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useStakingContract } from 'state/governance/hooks'
 import { useAppSelector } from 'state/hooks'
+import { usePoolMapFromUrl } from 'state/lists/poolsList/hooks'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 
 import { SupportedChainId } from '../../constants/chains'
@@ -113,6 +117,7 @@ function useFormattedPoolCreatedLogs(
 export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolean } {
   const { account, chainId } = useWeb3React()
   const registry = useRegistryContract()
+  const blockNumber = useBlockNumber()
 
   // get metadata from past events
   let registryStartBlock
@@ -128,7 +133,7 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
   } else if (chainId === SupportedChainId.POLYGON) {
     registryStartBlock = 35228892
   } else if (chainId === SupportedChainId.BNB) {
-    registryStartBlock = 25549625
+    registryStartBlock = typeof blockNumber === 'number' ? blockNumber - 40000 : 28843676
   } else {
     registryStartBlock = 1
   }
@@ -140,6 +145,8 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
     registryStartBlock
   )
 
+  const bscPools = useBscPools()
+
   // early return until events are fetched
   return useMemo(() => {
     //const formattedLogs = [...(formattedLogsV1 ?? [])]
@@ -149,9 +156,10 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
       return { loading: false }
     }
 
-    // TODO: check why quicknode returns error on log query, seems app keeps calling infura
-    // prevent display of bsc loader until fix quicknode rpc returned error
+    // TODO: we want to append pools from enpoint here and remove !formattedLogsV1 assertion
     if (chainId === 56 && registry && !formattedLogsV1) {
+      // eslint-disable-next-line
+      const pools = ([...(formattedLogsV1 ?? []), bscPools ?? []])
       return { data: [], loading: false }
     }
 
@@ -160,7 +168,29 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
     }
 
     return { data: formattedLogsV1, loading: false }
-  }, [account, chainId, formattedLogsV1, registry])
+  }, [account, chainId, formattedLogsV1, registry, bscPools])
+}
+
+// Bsc endpoints have eth_getLogs limit, so we query pools before recent history from pools list endpoint
+function useBscPools(): ChainTokenMap {
+  const allPoolsFromList = usePoolMapFromUrl(POOLS_LIST)
+
+  return useMemo(() => {
+    const chainTokenMap: ChainTokenMap = {}
+
+    Object.keys(allPoolsFromList).forEach((key) => {
+      const chainId = Number(key)
+      const tokenMap = chainTokenMap[chainId] ?? {}
+      Object.values(allPoolsFromList[chainId]).forEach(({ token }) => {
+        tokenMap[token.address] = token
+      })
+      if (chainId === SupportedChainId.BNB) {
+        chainTokenMap[chainId] = tokenMap
+      }
+    })
+
+    return chainTokenMap
+  }, [allPoolsFromList])
 }
 
 export function useCreateCallback(): (

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -4,6 +4,7 @@ import application from './application/reducer'
 import burn from './burn/reducer'
 import burnV3 from './burn/v3/reducer'
 import connection from './connection/reducer'
+import poolsList from './lists/poolsList/reducer'
 import lists from './lists/reducer'
 import logs from './logs/slice'
 import mint from './mint/reducer'
@@ -25,6 +26,7 @@ export default {
   burnV3,
   multicall: multicall.reducer,
   lists,
+  poolsList,
   logs,
   [routingApi.reducerPath]: routingApi.reducer,
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,19 +15,19 @@ export function isProductionEnv(): boolean {
   return process.env.NODE_ENV === 'production' && !isStagingEnv()
 }
 
-export function isAppUniswapOrg({ hostname }: { hostname: string }): boolean {
-  return hostname === 'app.uniswap.org'
+export function isAppRigoblockCom({ hostname }: { hostname: string }): boolean {
+  return hostname === 'app.rigoblock.com'
 }
 
-export function isAppUniswapStagingOrg({ hostname }: { hostname: string }): boolean {
-  return hostname === 'app.uniswap-staging.org'
+export function isAppRigoblockStagingCom({ hostname }: { hostname: string }): boolean {
+  return hostname === 'app.rigoblock-staging.com'
 }
 
 export function isSentryEnabled(): boolean {
   // Disable in e2e test environments
-  if (isStagingEnv() && !isAppUniswapStagingOrg(window.location)) return false
-  if (isProductionEnv() && !isAppUniswapOrg(window.location)) return false
-  return process.env.REACT_APP_SENTRY_ENABLED === 'true'
+  if (isStagingEnv() && !isAppRigoblockStagingCom(window.location)) return false
+  if (isProductionEnv()) return false
+  return process.env.REACT_APP_SENTRY_ENABLED === 'false'
 }
 
 export function getEnvName(): 'production' | 'staging' | 'development' {


### PR DESCRIPTION
This PR prepares setup for retrieving past pools from pools.rigoblock.com on bsc, as RPC providers have at max 100k eth_getLogs block limit. It also fixes an issue which prevented display of user tokens on account drawer.