### PR TITLE
fix: set adapter method declaration encoding

### DIFF
--- a/src/constants/addresses.ts
+++ b/src/constants/addresses.ts
@@ -30,7 +30,14 @@ export const UNISWAP_NFT_AIRDROP_CLAIM_ADDRESS = '0x8B799381ac40b838BBA4131ffB26
 export const V2_FACTORY_ADDRESSES: AddressMap = constructSameAddressMap(V2_FACTORY_ADDRESS)
 export const V2_ROUTER_ADDRESS: AddressMap = constructSameAddressMap('0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D')
 
-export const AUTHORITY_ADDRESSES: AddressMap = constructSameAddressMap('0xe35129A1E0BdB913CF6Fd8332E9d3533b5F41472')
+export const AUTHORITY_ADDRESSES: AddressMap = constructSameAddressMap('0xe35129A1E0BdB913CF6Fd8332E9d3533b5F41472', [
+  SupportedChainId.MAINNET,
+  SupportedChainId.GOERLI,
+  SupportedChainId.OPTIMISM,
+  SupportedChainId.ARBITRUM_ONE,
+  SupportedChainId.POLYGON,
+  SupportedChainId.BNB,
+])
 
 // celo v3 addresses
 const CELO_V3_CORE_FACTORY_ADDRESSES = '0xAfE208a311B21f13EF87E33A90049fC17A7acDEc'

--- a/src/pages/CreateProposal/index.tsx
+++ b/src/pages/CreateProposal/index.tsx
@@ -268,7 +268,7 @@ ${bodyValue}
         values = [[getAddress(toAddressValue), true]]
         interfaces = [new Interface(AUTHORITY_ABI)]
         targets = [AUTHORITY_ADDRESSES[chainId ?? 1]]
-        methods = ['setAdapter(address,bool)']
+        methods = ['setAdapter']
         break
       }
 
@@ -277,7 +277,7 @@ ${bodyValue}
         values = [[getAddress(toAddressValue), false]]
         interfaces = [new Interface(AUTHORITY_ABI)]
         targets = [AUTHORITY_ADDRESSES[chainId ?? 1]]
-        methods = ['setAdapter(address,bool)']
+        methods = ['setAdapter']
         break
       }
     }

--- a/src/pages/CreateProposal/index.tsx
+++ b/src/pages/CreateProposal/index.tsx
@@ -268,7 +268,7 @@ ${bodyValue}
         values = [[getAddress(toAddressValue), true]]
         interfaces = [new Interface(AUTHORITY_ABI)]
         targets = [AUTHORITY_ADDRESSES[chainId ?? 1]]
-        methods = ['setAdapter']
+        methods = ['setAdapter(address,bool)']
         break
       }
 
@@ -277,7 +277,7 @@ ${bodyValue}
         values = [[getAddress(toAddressValue), false]]
         interfaces = [new Interface(AUTHORITY_ABI)]
         targets = [AUTHORITY_ADDRESSES[chainId ?? 1]]
-        methods = ['setAdapter']
+        methods = ['setAdapter(address,bool)']
         break
       }
     }


### PR DESCRIPTION
This PR fixes an issue which returned an undefined target address by adding supported networks to the construct same address method in constants/addresses