### PR TITLE
fix: sort pools by stake

### DIFF
--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -105,7 +105,10 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
               <Trans>IRR</Trans>
               <MouseoverTooltip
                 text={
-                  <Trans>The pool operator&apos;s annualized yield. Increases as more stakers join the pool.</Trans>
+                  <Trans>
+                    The pool operator&apos;s annualized yield. Increases as more stakers join the pool. Decreases as the
+                    pool operator shares more of his revenue.
+                  </Trans>
                 }
                 placement="right"
               >

--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -27,7 +27,7 @@ const DesktopHeader = styled.div`
     justify-content: space-between;
     & > div:last-child {
       text-align: right;
-      margin-right: 8px;
+      margin-right: 12px;
     }
   }
 `
@@ -100,7 +100,7 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
           {positions && ' (' + operatedPools.length + ')'}
         </div>
         {!filterByOperator && (
-          <RowFixed gap="30px">
+          <RowFixed gap="32px">
             <RowFixed gap="2px">
               <Trans>IRR</Trans>
               <MouseoverTooltip
@@ -136,12 +136,12 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
       <MobileHeader>
         <div>{filterByOperator ? <Trans>Operated pools</Trans> : <Trans>Loaded pools</Trans>}</div>
         {!filterByOperator && (
-          <RowFixed style={{ gap: '40px' }}>
+          <RowFixed style={{ gap: '40px', marginRight: '8px' }}>
             <div>
-              <Trans>IRR&ensp;</Trans>
+              <Trans>IRR</Trans>
             </div>
             <div>
-              <Trans>APR&ensp;</Trans>
+              <Trans>APR</Trans>
             </div>
           </RowFixed>
         )}

--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -4,13 +4,16 @@ import { useWeb3React } from '@web3-react/core'
 import POOL_EXTENDED_ABI from 'abis/pool-extended.json'
 import PoolPositionListItem from 'components/PoolPositionListItem'
 import { RowFixed } from 'components/Row'
+import { InfoIconContainer } from 'components/Tokens/TokenTable/TokenRow'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { useMultipleContractSingleData } from 'lib/hooks/multicall'
 import React, { useMemo } from 'react'
+import { Info } from 'react-feather'
 import styled from 'styled-components/macro'
 import { MEDIA_WIDTHS } from 'theme'
 import { PoolPositionDetails } from 'types/position'
 
+// TODO: check if we want to keep margin right 12px by keeping list item margin right at 12px
 const DesktopHeader = styled.div`
   display: none;
   font-size: 14px;
@@ -24,7 +27,7 @@ const DesktopHeader = styled.div`
     justify-content: space-between;
     & > div:last-child {
       text-align: right;
-      margin-right: 12px;
+      margin-right: 8px;
     }
   }
 `
@@ -97,22 +100,36 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
           {positions && ' (' + operatedPools.length + ')'}
         </div>
         {!filterByOperator && (
-          <RowFixed style={{ gap: '40px' }}>
-            <MouseoverTooltip
-              text={<Trans>The pool operator&apos;s annualized yield. Increases as more stakers join the pool.</Trans>}
-            >
-              irr&ensp;
-            </MouseoverTooltip>
-            <MouseoverTooltip
-              text={
-                <Trans>
-                  The stakers&apos; annualized yield. Increases as the pool increases its own stake or as the pool
-                  operator increases the percent of rewards shared.
-                </Trans>
-              }
-            >
-              apr&ensp;
-            </MouseoverTooltip>
+          <RowFixed gap="30px">
+            <RowFixed gap="2px">
+              <Trans>IRR</Trans>
+              <MouseoverTooltip
+                text={
+                  <Trans>The pool operator&apos;s annualized yield. Increases as more stakers join the pool.</Trans>
+                }
+                placement="right"
+              >
+                <InfoIconContainer>
+                  <Info size={14} />
+                </InfoIconContainer>
+              </MouseoverTooltip>
+            </RowFixed>
+            <RowFixed gap="2px">
+              <Trans>APR</Trans>
+              <MouseoverTooltip
+                text={
+                  <Trans>
+                    The stakers&apos; annualized yield. Increases as the pool increases its own stake or as the pool
+                    operator increases the percent of rewards shared.
+                  </Trans>
+                }
+                placement="right"
+              >
+                <InfoIconContainer>
+                  <Info size={14} />
+                </InfoIconContainer>
+              </MouseoverTooltip>
+            </RowFixed>
           </RowFixed>
         )}
       </DesktopHeader>
@@ -121,10 +138,10 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
         {!filterByOperator && (
           <RowFixed style={{ gap: '40px' }}>
             <div>
-              <Trans>irr&ensp;</Trans>
+              <Trans>IRR&ensp;</Trans>
             </div>
             <div>
-              <Trans>apr&ensp;</Trans>
+              <Trans>APR&ensp;</Trans>
             </div>
           </RowFixed>
         )}

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -108,7 +108,7 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
         {returnPage === 'mint' ? (
           <DataText>{symbol}</DataText>
         ) : (
-          <RowFixed style={{ gap: '20px' }}>
+          <RowFixed style={{ gap: '24px', marginRight: '8px' }}>
             <DataText>{(Number(irr) * 100).toFixed(1)}%</DataText>
             <DataText>{(Number(apr) * 100).toFixed(1)}%</DataText>
           </RowFixed>

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -110,7 +110,7 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
         ) : (
           <RowFixed style={{ gap: '24px', marginRight: '8px' }}>
             <DataText>{(Number(irr) * 100).toFixed(1)}%</DataText>
-            <DataText>{(Number(apr) * 100).toFixed(1)}%</DataText>
+            <DataText style={{ minWidth: '50px' }}>{(Number(apr) * 100).toFixed(1)}%</DataText>
           </RowFixed>
         )}
       </RowBetween>

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -278,7 +278,7 @@ export const SparkLineLoadingBubble = styled(LongLoadingBubble)`
   height: 4px;
 `
 
-const InfoIconContainer = styled.div`
+export const InfoIconContainer = styled.div`
   margin-left: 2px;
   display: flex;
   align-items: center;

--- a/src/components/earn/MoveStakeModal.tsx
+++ b/src/components/earn/MoveStakeModal.tsx
@@ -76,10 +76,8 @@ export default function MoveStakeModal({ isOpen, poolInfo, isDeactivate, onDismi
   // TODO: we can save 1 rpc call here by using multicall
   const fromPoolId = usePoolIdByAddress(parsedAddress ?? undefined).poolId
   const { poolId, stakingPoolExists } = usePoolIdByAddress(poolInfo.pool?.address)
-  // hack to allow moving stake from deprecated pool
-  const defaultPoolId = '0x0000000000000000000000000000000000000000000000000000000000000021'
   const fromPoolStakeBalance = useStakeBalance(
-    isDeactivate ? poolId : fromPoolId ?? defaultPoolId,
+    isDeactivate ? poolId : fromPoolId,
     isPoolMoving ? poolInfo?.pool?.address : undefined
   )
   const poolContract = usePoolExtendedContract(poolInfo?.pool?.address)
@@ -98,12 +96,11 @@ export default function MoveStakeModal({ isOpen, poolInfo, isDeactivate, onDismi
     )
   )
 
-  // TODO: check if should return if no fromPoolId selected
-  const moveStakeData: StakeData | undefined = {
+  const moveStakeData: StakeData = {
     amount: parsedAmount?.quotient.toString(),
     pool: poolInfo.pool?.address,
-    fromPoolId: fromPoolId ?? defaultPoolId,
-    poolId: poolId ?? defaultPoolId,
+    fromPoolId,
+    poolId: poolId ?? '',
     poolContract: isPoolMoving ? poolContract : null,
     stakingPoolExists,
     isPoolMoving,
@@ -133,14 +130,7 @@ export default function MoveStakeModal({ isOpen, poolInfo, isDeactivate, onDismi
     setStakeAmount(parsedAmount)
 
     // if callback not returned properly ignore
-    if (
-      !moveStakeCallback ||
-      !deactivateStakeCallback ||
-      !fromPoolStakeBalance ||
-      !moveStakeData ||
-      !currencyValue.isToken
-    )
-      return
+    if (!moveStakeCallback || !deactivateStakeCallback || !fromPoolStakeBalance || !currencyValue.isToken) return
 
     const moveCallback = !isDeactivate ? moveStakeCallback : deactivateStakeCallback
 

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -85,8 +85,8 @@ const WrapSmall = styled(RowBetween)`
   `};
 `
 
-function highestAprFirst(a: any, b: any) {
-  return b.apr - a.apr
+function biggestOwnStakeFirst(a: any, b: any) {
+  return b.poolOwnStake - a.poolOwnStake
 }
 
 export default function Stake() {
@@ -136,13 +136,15 @@ export default function Stake() {
       .map((p, i) => {
         const apr = stakingPools?.[i].apr
         const irr = stakingPools?.[i].irr
+        const poolOwnStake = stakingPools?.[i].poolOwnStake
         return {
           ...p,
           irr,
           apr,
+          poolOwnStake,
         }
       })
-      .sort(highestAprFirst)
+      .sort(biggestOwnStakeFirst)
   }, [allPools, stakingPools])
 
   // TODO: useStakingPools hook also returns stake, ownStake, can use as filter and add stake to page

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -23,7 +23,7 @@ import PoolPositionList from '../../components/PoolPositionList'
 import { RowBetween, RowFixed } from '../../components/Row'
 //import { LoadingSparkle } from '../../nft/components/common/Loading/LoadingSparkle'
 import { Center } from '../../nft/components/Flex'
-import { PoolRegisteredLog, useBscPools, useRegisteredPools, useRegistryContract } from '../../state/pool/hooks'
+import { PoolRegisteredLog, useAllPoolsData, useBscPools, useRegistryContract } from '../../state/pool/hooks'
 import { useUnclaimedRewards } from '../../state/stake/hooks'
 import { ThemedText } from '../../theme'
 //import { PoolPositionDetails } from '../../types/position'
@@ -97,8 +97,8 @@ export default function Stake() {
   const [hasMore, setHasMore] = useState(true)
   const [records, setRecords] = useState(itemsPerPage)
 
-  // TODO: return loading
-  const smartPoolsLogs = useRegisteredPools()
+  // we retrieve logs again as we want to be able to load pools when switching chain from stake page.
+  const { data: smartPoolsLogs, loading } = useAllPoolsData()
   const registry = useRegistryContract()
   const bscPools = useBscPools(registry)
 
@@ -107,9 +107,10 @@ export default function Stake() {
   const hasFreeStake = JSBI.greaterThan(freeStakeBalance ? freeStakeBalance.quotient : JSBI.BigInt(0), JSBI.BigInt(0))
 
   const allPools: PoolRegisteredLog[] = useMemo(() => {
+    if (loading) return []
     if (chainId === SupportedChainId.BNB) return [...(smartPoolsLogs ?? []), ...(bscPools ?? [])]
     return [...(smartPoolsLogs ?? [])]
-  }, [chainId, smartPoolsLogs, bscPools])
+  }, [chainId, loading, smartPoolsLogs, bscPools])
 
   const poolAddresses = allPools.map((p) => p.pool)
   const poolIds = allPools.map((p) => p.id)


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
This PR sorts pools by pool own stake, thus helping users select pools where impact of delegating will be minor.
It also applies some minor display improvements.
Some improvements are added, like querying pools logs from staking page, allowing user to view pools when switching chain without having to move to create pool tab first. That only costs one extra call when loading the page, since the regitered logs hook still prompts update logs at intervals. Default pool id is removed from code as the default pool id has been fully unstaked and deprecated.
