### PR TITLE
feat: display staked pools

### DIFF
--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -164,17 +164,11 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
         <>
           <DesktopHeader>
             <div>
-              <Trans>
-                You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one or search through
-                the existing ones.
-              </Trans>
+              <Trans>You are not operating a smart pool. Create yours or search an existing one.</Trans>
             </div>
           </DesktopHeader>
           <MobileHeader>
-            <Trans>
-              You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one or search through the
-              existing ones.
-            </Trans>
+            <Trans>You are not operating a smart pool. Create yours or search an existing one.</Trans>
           </MobileHeader>
         </>
       )}

--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -69,7 +69,7 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
   const results = useMultipleContractSingleData(poolAddresses, PoolInterface, 'getPool')
   // TODO: if we initiate this in state, we can later query from state instead of making rpc call
   //  in 1) swap and 2) each pool url, we could also store poolId at that point
-  const operatedPools = useMemo(() => {
+  const poolsWithStats = useMemo(() => {
     return results
       .map((result, i) => {
         const { result: pools, loading } = result
@@ -98,7 +98,7 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
       <DesktopHeader>
         <div>
           {filterByOperator ? <Trans>Operated pools</Trans> : <Trans>Loaded pools</Trans>}
-          {positions && ' (' + operatedPools.length + ')'}
+          {positions && ' (' + poolsWithStats.length + ')'}
         </div>
         {!filterByOperator && (
           <RowFixed gap="32px">
@@ -150,8 +150,8 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
           </RowFixed>
         )}
       </MobileHeader>
-      {operatedPools.length !== 0 ? (
-        operatedPools.map((p: any) => {
+      {poolsWithStats.length !== 0 ? (
+        poolsWithStats.map((p: any) => {
           return (
             <PoolPositionListItem
               key={p?.address.toString()}

--- a/src/components/PoolPositionList/index.tsx
+++ b/src/components/PoolPositionList/index.tsx
@@ -82,6 +82,7 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
           ...result,
           apr: positions[i].apr,
           irr: positions[i].irr,
+          userHasStake: positions[i].userHasStake,
           address,
           decimals,
           symbol,
@@ -163,11 +164,17 @@ export default function PoolPositionList({ positions, filterByOperator }: PoolPo
         <>
           <DesktopHeader>
             <div>
-              <Trans>You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one.</Trans>
+              <Trans>
+                You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one or search through
+                the existing ones.
+              </Trans>
             </div>
           </DesktopHeader>
           <MobileHeader>
-            <Trans>You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one.</Trans>
+            <Trans>
+              You are not operating a pool. Click the &quot;Create Pool&quot; button to deploy one or search through the
+              existing ones.
+            </Trans>
           </MobileHeader>
         </>
       )}

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -1,13 +1,13 @@
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 //import Badge from 'components/Badge'
 //import RangeBadge from 'components/Badge/RangeBadge'
 //import Loader from 'components/Loader'
-import { RowBetween, RowFixed } from 'components/Row'
+import Row, { RowBetween, RowFixed } from 'components/Row'
 //import { useToken } from 'hooks/Tokens'
 //import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
-import { MEDIA_WIDTHS } from 'theme'
+import { MEDIA_WIDTHS, ThemedText } from 'theme'
 import { PoolPositionDetails } from 'types/position'
 
 const LinkRow = styled(Link)`
@@ -84,6 +84,16 @@ const ExtentsText = styled.span`
   `};
 `
 
+const ActiveDot = styled.span<{ closed: boolean; outOfRange: boolean }>`
+  background-color: ${({ theme, closed, outOfRange }) =>
+    closed ? theme.textSecondary : outOfRange ? theme.accentWarning : theme.accentSuccess};
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+  margin-left: 4px;
+  margin-top: 1px;
+`
+
 interface PoolPositionListItemProps {
   positionDetails: PoolPositionDetails
   returnPage: string
@@ -104,8 +114,17 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
     <LinkRow to={positionSummaryLink}>
       <RowBetween>
         <PrimaryPositionIdData>
-          <DataText>{name}</DataText>
-          {userHasStake && <Trans>staked</Trans>}
+          <Row gap="sm" justify="flex-end">
+            <Row>
+              <DataText>{name}</DataText>
+            </Row>
+            {userHasStake && (
+              <>
+                <ThemedText.Caption color="textSecondary">{t`active`}</ThemedText.Caption>
+                <ActiveDot closed={false} outOfRange={false} />
+              </>
+            )}
+          </Row>
         </PrimaryPositionIdData>
         {returnPage === 'mint' ? (
           <DataText>{symbol}</DataText>

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -90,7 +90,7 @@ interface PoolPositionListItemProps {
 }
 
 export default function PoolPositionListItem({ positionDetails, returnPage }: PoolPositionListItemProps) {
-  const { name, symbol, apr, irr } = positionDetails
+  const { name, symbol, apr, irr, userHasStake } = positionDetails
 
   //const position = useMemo(() => {
   //  return new PoolPosition({ name, symbol, pool, id })
@@ -99,11 +99,13 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
   //const positionSummaryLink = '/smart-pool/' + positionDetails.pool '/' + positionDetails.id
   const positionSummaryLink = `/smart-pool/${positionDetails.address}/${returnPage}` ///${positionDetails.id}
 
+  // TODO: change >staked< to something more sexy
   return (
     <LinkRow to={positionSummaryLink}>
       <RowBetween>
         <PrimaryPositionIdData>
           <DataText>{name}</DataText>
+          {userHasStake && <Trans>staked</Trans>}
         </PrimaryPositionIdData>
         {returnPage === 'mint' ? (
           <DataText>{symbol}</DataText>

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 //import Badge from 'components/Badge'
 //import RangeBadge from 'components/Badge/RangeBadge'
 //import Loader from 'components/Loader'
@@ -6,8 +6,8 @@ import Row, { RowBetween, RowFixed } from 'components/Row'
 //import { useToken } from 'hooks/Tokens'
 //import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components/macro'
-import { MEDIA_WIDTHS, ThemedText } from 'theme'
+import styled, { useTheme } from 'styled-components/macro'
+import { MEDIA_WIDTHS } from 'theme'
 import { PoolPositionDetails } from 'types/position'
 
 const LinkRow = styled(Link)`
@@ -84,14 +84,26 @@ const ExtentsText = styled.span`
   `};
 `
 
-const ActiveDot = styled.span<{ closed: boolean; outOfRange: boolean }>`
-  background-color: ${({ theme, closed, outOfRange }) =>
-    closed ? theme.textSecondary : outOfRange ? theme.accentWarning : theme.accentSuccess};
+const LabelText = styled.div<{ color: string }>`
+  align-items: center;
+  color: ${({ color }) => color};
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`
+
+const BadgeText = styled.div`
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 14px;
+  margin-right: 4px;
+`
+
+const ActiveDot = styled.span`
+  background-color: ${({ theme }) => theme.accentSuccess};
   border-radius: 50%;
   height: 8px;
   width: 8px;
-  margin-left: 4px;
-  margin-top: 1px;
 `
 
 interface PoolPositionListItemProps {
@@ -100,6 +112,7 @@ interface PoolPositionListItemProps {
 }
 
 export default function PoolPositionListItem({ positionDetails, returnPage }: PoolPositionListItemProps) {
+  const theme = useTheme()
   const { name, symbol, apr, irr, userHasStake } = positionDetails
 
   //const position = useMemo(() => {
@@ -109,20 +122,19 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
   //const positionSummaryLink = '/smart-pool/' + positionDetails.pool '/' + positionDetails.id
   const positionSummaryLink = `/smart-pool/${positionDetails.address}/${returnPage}` ///${positionDetails.id}
 
-  // TODO: change >staked< to something more sexy
   return (
     <LinkRow to={positionSummaryLink}>
       <RowBetween>
         <PrimaryPositionIdData>
           <Row gap="sm" justify="flex-end">
-            <Row>
-              <DataText>{name}</DataText>
-            </Row>
+            <DataText>{name}</DataText>
             {userHasStake && (
-              <>
-                <ThemedText.Caption color="textSecondary">{t`active`}</ThemedText.Caption>
-                <ActiveDot closed={false} outOfRange={false} />
-              </>
+              <LabelText color={theme.accentSuccess}>
+                <BadgeText>
+                  <Trans>active</Trans>
+                </BadgeText>
+                <ActiveDot />
+              </LabelText>
             )}
           </Row>
         </PrimaryPositionIdData>

--- a/src/components/vote/DelegateModal.tsx
+++ b/src/components/vote/DelegateModal.tsx
@@ -223,7 +223,11 @@ export default function DelegateModal({ isOpen, poolInfo, onDismiss, title }: Vo
               </AutoColumn>
             </LightCard>
             <ButtonPrimary
-              disabled={!isAddress(parsedAddress ?? '') || approval !== ApprovalState.APPROVED}
+              disabled={
+                !isAddress(parsedAddress ?? '') ||
+                approval !== ApprovalState.APPROVED ||
+                formatCurrencyAmount(parsedAmount, 4) === '0'
+              }
               onClick={onDelegate}
             >
               <ThemedText.DeprecatedMediumHeader color="white">

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -81,9 +81,8 @@ const WrapSmall = styled(RowBetween)`
   `};
 `
 
-// TODO: check method renaming as we display staked pools first
 function biggestOwnStakeFirst(a: any, b: any) {
-  return b.hasStake - a.hasStake || b.poolOwnStake - a.poolOwnStake
+  return b.poolOwnStake - a.poolOwnStake
 }
 
 export default function Stake() {

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -460,7 +460,6 @@ export function usePoolIdByAddress(pool: string | undefined): {
   else return { poolId, stakingPoolExists }
 }
 
-// TODO: we must return a currency balance
 export function useStakeBalance(
   poolId: string | null | undefined,
   owner?: string

--- a/src/state/pool/hooks.ts
+++ b/src/state/pool/hooks.ts
@@ -49,6 +49,7 @@ export interface PoolRegisteredLog {
   name: string
   symbol: string
   id: string
+  userHasStake?: boolean
 }
 
 function useStartBlock(chainId: number | undefined): number | undefined {
@@ -338,7 +339,7 @@ export function useStakingPools(addresses: string[] | undefined, poolIds: string
 
   const poolsData = useSingleContractMultipleData(stakingContract, 'getStakingPool', inputs)
   const poolsStakes = useSingleContractMultipleData(stakingContract, 'getTotalStakeDelegatedToPool', inputs)
-  // TODO: if we allow pools to stake pools other then self we'll have to use getStakeDelegateToPoolByOwner
+  // TODO: if we allow pools to stake pools other then self we'll have to use getStakeDelegatedToPoolByOwner
   const poolsOwnStakes = useSingleContractMultipleData(stakingContract, 'getOwnerStakeByStatus', poolAddresses)
 
   const poolsLoading = useMemo(() => poolsData.some(({ loading }) => loading), [poolsData])

--- a/src/types/position.d.ts
+++ b/src/types/position.d.ts
@@ -26,4 +26,5 @@ export interface PoolPositionDetails {
   address?: string
   apr?: string
   irr?: string
+  userHasStake?: boolean
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

Displaying an actively stkaed pools flag with text and green dot if user has active stake in pool on list.
Pools are sorted by user active position and pool own stake, thus displaying first in the list pools where user has an active stake.