### PR TITLE
fix: remove duplicate pools

### DIFF
--- a/src/components/NavBar/SearchBar.tsx
+++ b/src/components/NavBar/SearchBar.tsx
@@ -2,7 +2,7 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { BrowserEvent, InterfaceElementName, InterfaceEventName, InterfaceSectionName } from '@uniswap/analytics-events'
-import { ChainId, Token } from '@uniswap/sdk-core'
+import { Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { sendAnalyticsEvent, Trace, TraceEvent, useTrace } from 'analytics'
 import clsx from 'clsx'
@@ -74,13 +74,10 @@ export const SearchBar = () => {
   const registry = useRegistryContract()
   const poolsFromList = usePoolsFromList(registry, chainId)
 
-  // TODO: we might remove the condition and append pools from url as fallback in case endpoint is down or slow on all chains
+  // we append pools from url as fallback in case endpoint is down or slow.
   const allPools: PoolRegisteredLog[] = useMemo(() => {
-    if (chainId === ChainId.BNB || chainId === ChainId.BASE || chainId === ChainId.OPTIMISM) {
-      return [...(smartPoolsLogs ?? []), ...(poolsFromList ?? [])]
-    }
-    return [...(smartPoolsLogs ?? [])]
-  }, [chainId, smartPoolsLogs, poolsFromList])
+    return [...(smartPoolsLogs ?? []), ...(poolsFromList ?? [])]
+  }, [smartPoolsLogs, poolsFromList])
 
   const uniquePools = allPools.filter((obj, index) => {
     return index === allPools.findIndex((o) => obj.pool === o.pool)

--- a/src/components/createPool/SetValueModal.tsx
+++ b/src/components/createPool/SetValueModal.tsx
@@ -101,7 +101,7 @@ export default function SetValueModal({ isOpen, onDismiss, poolInfo, title }: Se
               <Trans>New value must be between 1/5th and 5 times the current value.</Trans>
             </ThemedText.DeprecatedBody>
             <ThemedText.DeprecatedBody>
-              <Trans>Pool base token liquidity must be at least 3% of new unitary value.</Trans>
+              <Trans>Pool base token balance must be at least 3% of new pool value.</Trans>
             </ThemedText.DeprecatedBody>
             <NameInputPanel value={typed} onChange={onUserInput} label="Unitary Value" placeholder="New Value" />
             {/* TODO: disables if same as current */}

--- a/src/components/swap/GasBreakdownTooltip.tsx
+++ b/src/components/swap/GasBreakdownTooltip.tsx
@@ -47,8 +47,8 @@ const GasCostItem = ({
 
 export function GasBreakdownTooltip({
   trade,
-  hideFees = false,
-  hideUniswapXDescription = false,
+  hideFees = true,
+  hideUniswapXDescription = true,
 }: {
   trade: InterfaceTrade
   hideFees?: boolean
@@ -93,7 +93,7 @@ export function GasBreakdownTooltip({
       ) : (
         <ThemedText.Caption color="textSecondary">
           <Trans>Network Fees are paid to the Ethereum network to secure transactions.</Trans>{' '}
-          <ExternalLink href="https://support.uniswap.org/hc/en-us/articles/8370337377805-What-is-a-network-fee-">
+          <ExternalLink href="https://ethereum.org/en/developers/docs/gas/">
             <InlineLink>
               <Trans>Learn more</Trans>
             </InlineLink>

--- a/src/graphql/data/util.tsx
+++ b/src/graphql/data/util.tsx
@@ -190,7 +190,7 @@ export const BACKEND_SUPPORTED_CHAINS = [
   Chain.Celo,
   Chain.Base,
 ] as const
-export const BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS = [ChainId.BNB, ChainId.AVALANCHE] as const
+export const BACKEND_NOT_YET_SUPPORTED_CHAIN_IDS = [ChainId.AVALANCHE] as const
 
 export function getTokenDetailsURL({
   address,

--- a/src/state/pool/hooks.ts
+++ b/src/state/pool/hooks.ts
@@ -43,6 +43,7 @@ export function usePoolExtendedContract(poolAddress: string | undefined): Contra
   return useContract(poolAddress, POOL_EXTENDED_ABI, true)
 }
 
+// TODO: id should be optional as not returned in pools from url
 export interface PoolRegisteredLog {
   group?: string
   pool: string
@@ -161,11 +162,17 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
       return { loading: false }
     }
 
-    // TODO: we might have temporary duplicate non-identical pools as group is empty in pools from endpoint
+    // TODO: we might attach pools from url and filter duplicates on all chains to allow display if log response
+    //  is slow or returns an error.
     if ((chainId === ChainId.BNB || chainId === ChainId.BASE || chainId === ChainId.OPTIMISM) && registry) {
       // eslint-disable-next-line
       const pools: PoolRegisteredLog[] = ([...(formattedLogsV1 ?? []), ...(poolsFromList ?? [])])
-      return { data: pools, loading: false }
+
+      const uniquePools = pools.filter((obj, index) => {
+        return index === pools.findIndex((o) => obj.pool === o.pool)
+      })
+
+      return { data: uniquePools, loading: false }
     }
 
     if (registry && !formattedLogsV1) {

--- a/src/state/pool/hooks.ts
+++ b/src/state/pool/hooks.ts
@@ -155,32 +155,25 @@ export function useAllPoolsData(): { data?: PoolRegisteredLog[]; loading: boolea
 
   // early return until events are fetched
   return useMemo(() => {
-    //const formattedLogs = [...(formattedLogsV1 ?? [])]
-
     // prevent display if wallet not connected
     if (!account) {
       return { loading: false }
     }
 
-    // TODO: we might attach pools from url and filter duplicates on all chains to allow display if log response
-    //  is slow or returns an error.
-    if ((chainId === ChainId.BNB || chainId === ChainId.BASE || chainId === ChainId.OPTIMISM) && registry) {
-      // eslint-disable-next-line
-      const pools: PoolRegisteredLog[] = ([...(formattedLogsV1 ?? []), ...(poolsFromList ?? [])])
+    // we append pools from url and filter for duplicates in case the rpc endpoint is down or slow.
+    // eslint-disable-next-line
+    const pools: PoolRegisteredLog[] = ([...(formattedLogsV1 ?? []), ...(poolsFromList ?? [])])
 
-      const uniquePools = pools.filter((obj, index) => {
-        return index === pools.findIndex((o) => obj.pool === o.pool)
-      })
+    const uniquePools = pools.filter((obj, index) => {
+      return index === pools.findIndex((o) => obj.pool === o.pool)
+    })
 
-      return { data: uniquePools, loading: false }
-    }
-
-    if (registry && !formattedLogsV1) {
+    if (registry && !uniquePools) {
       return { data: [], loading: true }
     }
 
-    return { data: formattedLogsV1, loading: false }
-  }, [account, chainId, formattedLogsV1, registry, poolsFromList])
+    return { data: uniquePools, loading: false }
+  }, [account, formattedLogsV1, registry, poolsFromList])
 }
 
 // Bsc endpoints have eth_getLogs limit, so we query pools before recent history from pools list endpoint


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
This PR removed duplicate pools on Optimism when both pools from url and from endpoint are returned. It also appends pools from public url and filters out duplicates for all chains, which allows viewing historical pools in case an rpc endpoint is down or slow.

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
