### PR TITLE
feat: display held pools

### DIFF
--- a/src/components/MendableSearch/index.tsx
+++ b/src/components/MendableSearch/index.tsx
@@ -8,7 +8,7 @@ const StyledSearch = styled.div`
   display: flex;
   align-items: center;
   right: 0;
-  bottom: 0;
+  bottom: 2rem;
   padding: 1rem;
   color: theme.deprecated_yellow3;
   transition: 250ms ease color;

--- a/src/components/Polling/index.tsx
+++ b/src/components/Polling/index.tsx
@@ -18,7 +18,6 @@ import { ChainConnectivityWarning } from './ChainConnectivityWarning'
 
 const StyledPolling = styled.div`
   align-items: center;
-  left: 0;
   bottom: 0;
   color: ${({ theme }) => theme.textTertiary};
   display: none;

--- a/src/components/PoolPositionListItem/index.tsx
+++ b/src/components/PoolPositionListItem/index.tsx
@@ -113,7 +113,7 @@ interface PoolPositionListItemProps {
 
 export default function PoolPositionListItem({ positionDetails, returnPage }: PoolPositionListItemProps) {
   const theme = useTheme()
-  const { name, symbol, apr, irr, userHasStake, poolDelegatedStake } = positionDetails
+  const { name, symbol, apr, irr, userHasStake, poolDelegatedStake, userBalance, userIsOwner } = positionDetails
 
   //const position = useMemo(() => {
   //  return new PoolPosition({ name, symbol, pool, id })
@@ -135,6 +135,22 @@ export default function PoolPositionListItem({ positionDetails, returnPage }: Po
               <LabelText color={theme.accentSuccess}>
                 <BadgeText>
                   <Trans>active</Trans>
+                </BadgeText>
+                <ActiveDot />
+              </LabelText>
+            )}
+            {returnPage === 'mint' && Number(userBalance) > 0 && (
+              <LabelText color={theme.accentSuccess}>
+                <BadgeText>
+                  <Trans>held</Trans>
+                </BadgeText>
+                <ActiveDot />
+              </LabelText>
+            )}
+            {returnPage === 'mint' && userIsOwner && (
+              <LabelText color={theme.accentSuccess}>
+                <BadgeText>
+                  <Trans>owned</Trans>
                 </BadgeText>
                 <ActiveDot />
               </LabelText>

--- a/src/types/position.d.ts
+++ b/src/types/position.d.ts
@@ -27,5 +27,7 @@ export interface PoolPositionDetails {
   irr?: string
   poolOwnStake?: BigNumber
   poolDelegatedStake?: BigNumber
+  userBalance?: BigNumber
   userHasStake?: boolean
+  userIsOwner?: boolean
 }


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->

This PR displays held pools alongside owned pools in the "mint" page. Pools are flagged as held, owned, or both. It also moves the Mendable search component to increase clickable area and moves the block number back to its original place.

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
