### PR TITLE
fix: check if token whitelisted before call

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -706,6 +706,7 @@ export function Swap({
           originalTrade={tradeToConfirm}
           onAcceptChanges={handleAcceptChanges}
           onCurrencySelection={onCurrencySelection}
+          selectedPool={smartPool}
           swapResult={swapResult}
           allowedSlippage={allowedSlippage}
           onConfirm={handleSwap}

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -299,8 +299,5 @@ export function useIsWhitelistedToken(poolAddress?: string, token?: Currency): b
     token?.isToken ? token.address : undefined,
   ])?.result?.[0]
 
-  return useMemo(
-    () => (token?.isToken ? isWhitelistedToken : Boolean(poolAddress && token?.isNative) ?? false),
-    [poolAddress, token, isWhitelistedToken]
-  )
+  return useMemo(() => (token?.isToken ? isWhitelistedToken : true), [token, isWhitelistedToken])
 }

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -3,12 +3,14 @@ import { ChainId, Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/
 import { useWeb3React } from '@web3-react/core'
 import useAutoSlippageTolerance from 'hooks/useAutoSlippageTolerance'
 import { useDebouncedTrade } from 'hooks/useDebouncedTrade'
+import { useSingleCallResult } from 'lib/hooks/multicall'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
 import { ReactNode, useCallback, useEffect, useMemo } from 'react'
 import { AnyAction } from 'redux'
 import { useActiveSmartPool } from 'state/application/hooks'
 import { useAppDispatch } from 'state/hooks'
+import { usePoolExtendedContract } from 'state/pool/hooks'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
 import { isClassicTrade, isUniswapXTrade } from 'state/routing/utils'
 import { useUserSlippageToleranceWithDefault } from 'state/user/hooks'
@@ -288,4 +290,17 @@ export function useDefaultsFromURLSearch(): SwapState {
   }, [dispatch, chainId, parsedSwapState])
 
   return parsedSwapState
+}
+
+export function useIsWhitelistedToken(poolAddress?: string, token?: Currency): boolean | undefined {
+  const contract = usePoolExtendedContract(poolAddress)
+
+  const isWhitelistedToken: boolean | undefined = useSingleCallResult(contract, 'isWhitelistedToken', [
+    token?.isToken ? token.address : undefined,
+  ])?.result?.[0]
+
+  return useMemo(
+    () => (token?.isToken ? isWhitelistedToken : Boolean(poolAddress && token?.isNative) ?? false),
+    [poolAddress, token, isWhitelistedToken]
+  )
 }


### PR DESCRIPTION

<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- assert whether the token is whitelisted when reviewing the transaction
- return error modal if token not whitelisted
- remove error return when a transaction reverts on a non-whitelisted token, as now the error is prevented before sending the txn
- pass additional param selectedPool to confirm swap modal child from swap page
- add hook to check onchain if a token is whitelisted in /swap/hooks

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
