### PR TITLE
fix: return error on sell when pool does not have enough

### DIFF
--- a/src/components/createPool/SellModal.tsx
+++ b/src/components/createPool/SellModal.tsx
@@ -99,16 +99,12 @@ export default function SellModal({
     }
   }, [parsedAmount, poolInfo])
 
-  // TODO: when expected amount is 0 or null should return true
   // it is possible that user is requesting more that its balance
   const poolHoldsEnough: boolean = useMemo(() => {
     if (!poolBaseTokenBalance || !expectedBaseTokens || !parsedAmount || !poolInfo) return true
-    //if (JSBI.equal(expectedBaseTokens.quotient, JSBI.BigInt(0))) return true
-    // if a user is requesting more than it holds, the expected base token amount will always be 0
     if (JSBI.greaterThanOrEqual(parsedAmount.quotient, poolInfo?.userPoolBalance.quotient)) return false
     return JSBI.greaterThanOrEqual(poolBaseTokenBalance.quotient, expectedBaseTokens.quotient)
   }, [poolBaseTokenBalance, expectedBaseTokens, parsedAmount, poolInfo])
-  //console.log(poolHoldsEnough)
 
   async function onSell() {
     setAttempting(true)
@@ -147,7 +143,6 @@ export default function SellModal({
   const handleMax = useCallback(() => {
     maxAmountInput && onUserInput(maxAmountInput.toExact())
   }, [maxAmountInput, onUserInput])
-  console.log(error)
 
   return (
     <Modal isOpen={isOpen} onDismiss={wrappedOnDismiss} maxHeight={90}>

--- a/src/components/createPool/SellModal.tsx
+++ b/src/components/createPool/SellModal.tsx
@@ -32,9 +32,16 @@ interface PoolModalProps {
   onDismiss: () => void
   poolInfo?: PoolInfo
   userBaseTokenBalance?: CurrencyAmount<Currency>
+  poolBaseTokenBalance?: CurrencyAmount<Currency>
 }
 
-export default function SellModal({ isOpen, onDismiss, poolInfo, userBaseTokenBalance }: PoolModalProps) {
+export default function SellModal({
+  isOpen,
+  onDismiss,
+  poolInfo,
+  userBaseTokenBalance,
+  poolBaseTokenBalance,
+}: PoolModalProps) {
   //const { provider } = useWeb3React()
 
   // track and parse user input
@@ -91,6 +98,12 @@ export default function SellModal({ isOpen, onDismiss, poolInfo, userBaseTokenBa
       minimumAmount: CurrencyAmount.fromRawAmount(parsedAmount.currency, minimumAmount),
     }
   }, [parsedAmount, poolInfo])
+
+  // TODO: when expected amount is 0 or null should return true
+  const poolHoldsEnough: boolean = JSBI.greaterThanOrEqual(
+    poolBaseTokenBalance?.quotient ?? JSBI.BigInt(0),
+    expectedBaseTokens?.quotient ?? JSBI.BigInt(0)
+  )
 
   async function onSell() {
     setAttempting(true)
@@ -159,8 +172,16 @@ export default function SellModal({ isOpen, onDismiss, poolInfo, userBaseTokenBa
           )}
 
           <RowBetween>
-            <ButtonError disabled={!!error} error={!!error && !!parsedAmount} onClick={onSell}>
-              {error ?? <Trans>Sell</Trans>}
+            <ButtonError
+              disabled={!!error || !poolHoldsEnough}
+              error={(!!error || !poolHoldsEnough) && !!parsedAmount}
+              onClick={onSell}
+            >
+              {error ?? !poolHoldsEnough ? (
+                <Trans>Pool does not hold enough {poolInfo?.poolPriceAmount?.currency.symbol}</Trans>
+              ) : (
+                <Trans>Sell</Trans>
+              )}
             </ButtonError>
           </RowBetween>
           {/* TODO: check these circles */}

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -8,7 +8,7 @@ import { useMultipleContractSingleData, useSingleContractMultipleData } from 'li
 import { useMemo } from 'react'
 
 import { nativeOnChain } from '../../constants/tokens'
-import { useInterfaceMulticall } from '../../hooks/useContract'
+import { useInterfaceMulticall, useTokenContract } from '../../hooks/useContract'
 import { isAddress } from '../../utils'
 
 /**
@@ -48,6 +48,59 @@ export function useNativeCurrencyBalances(uncheckedAddresses?: (string | undefin
 
 const ERC20Interface = new Interface(ERC20ABI) as Erc20Interface
 const tokenBalancesGasRequirement = { gasRequired: 185_000 }
+
+/**
+ * Returns a currency address to its eventually consistent currency balances for multiple account.
+ */
+export function useCurrencyBalancesMultipleAccounts(
+  uncheckedAddresses?: (string | undefined)[],
+  currency?: Currency | undefined
+): {
+  [address: string]: CurrencyAmount<Currency> | undefined
+} {
+  const { chainId } = useWeb3React()
+  const multicallContract = useInterfaceMulticall()
+
+  // TODO: no need to sort here, we already know the order defined in type
+  const validAddressInputs: [string][] = useMemo(
+    () =>
+      uncheckedAddresses
+        ? uncheckedAddresses
+            .map(isAddress)
+            .filter((a): a is string => a !== false)
+            //.sort()
+            .map((addr) => [addr])
+        : [],
+    [uncheckedAddresses]
+  )
+
+  const validatedToken: Token | undefined = useMemo(
+    () => (!currency?.isNative && isAddress(currency?.address) && currency?.chainId === chainId ? currency : undefined),
+    [chainId, currency]
+  )
+
+  const tokenContract = useTokenContract(validatedToken?.address, false)
+  //const isNativeCurrency: boolean = useMemo(() => currency?.isNative ?? false, [currency])
+  const balances = useSingleContractMultipleData(
+    tokenContract ?? multicallContract,
+    tokenContract ? 'balanceOf' : 'getEthBalance',
+    validAddressInputs
+  )
+
+  return useMemo(
+    () =>
+      validAddressInputs.reduce<{ [address: string]: CurrencyAmount<Currency> }>((memo, [address], i) => {
+        const value = balances?.[i]?.result?.[0]
+        if (value && chainId)
+          memo[address] = CurrencyAmount.fromRawAmount(
+            validatedToken ?? nativeOnChain(chainId),
+            JSBI.BigInt(value.toString())
+          )
+        return memo
+      }, {}),
+    [validAddressInputs, chainId, balances, validatedToken]
+  )
+}
 
 /**
  * Returns a map of token addresses to their eventually consistent token balances for a single account.

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -80,7 +80,6 @@ export function useCurrencyBalancesMultipleAccounts(
   )
 
   const tokenContract = useTokenContract(validatedToken?.address, false)
-  //const isNativeCurrency: boolean = useMemo(() => currency?.isNative ?? false, [currency])
   const balances = useSingleContractMultipleData(
     tokenContract ?? multicallContract,
     tokenContract ? 'balanceOf' : 'getEthBalance',

--- a/src/lib/hooks/useCurrencyBalance.ts
+++ b/src/lib/hooks/useCurrencyBalance.ts
@@ -61,14 +61,13 @@ export function useCurrencyBalancesMultipleAccounts(
   const { chainId } = useWeb3React()
   const multicallContract = useInterfaceMulticall()
 
-  // TODO: no need to sort here, we already know the order defined in type
   const validAddressInputs: [string][] = useMemo(
     () =>
       uncheckedAddresses
         ? uncheckedAddresses
             .map(isAddress)
             .filter((a): a is string => a !== false)
-            //.sort()
+            .sort()
             .map((addr) => [addr])
         : [],
     [uncheckedAddresses]
@@ -86,6 +85,7 @@ export function useCurrencyBalancesMultipleAccounts(
     validAddressInputs
   )
 
+  // if a type is returned instead of a mapping, must assert no sort() op is performed.
   return useMemo(
     () =>
       validAddressInputs.reduce<{ [address: string]: CurrencyAmount<Currency> }>((memo, [address], i) => {

--- a/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/src/pages/CreatePool/PoolPositionPage.tsx
@@ -44,7 +44,7 @@ import { Link, useParams } from 'react-router-dom'
 //import { Bound } from 'state/mint/v3/actions'
 import { PoolInfo } from 'state/buy/hooks'
 //import { useTokenBalance } from 'state/connection/hooks'
-import { useCurrencyBalance } from 'state/connection/hooks'
+import { /*useCurrencyBalance,*/ useCurrencyBalancesMultipleAccounts } from 'state/connection/hooks'
 import { usePoolIdByAddress } from 'state/governance/hooks'
 import { useFreeStakeBalance, useUnclaimedRewards } from 'state/stake/hooks'
 //import { useIsTransactionPending, useTransactionAdder } from 'state/transactions/hooks'
@@ -309,7 +309,11 @@ export function PoolPositionPage() {
     poolOwnStake: Number(poolOwnStakeFromUrl),
     irr: Number(irrFromUrl),
   } as PoolInfo
-  const userBaseTokenBalance = useCurrencyBalance(account ?? undefined, base ?? undefined)
+  //const userBaseTokenBalance = useCurrencyBalance(account ?? undefined, base ?? undefined)
+  const baseTokenBalances = useCurrencyBalancesMultipleAccounts(
+    [account ?? undefined, poolAddressFromUrl ?? undefined],
+    base ?? undefined
+  )
 
   // TODO: check how improve efficiency as this method is called each time a pool is loaded
   const { poolId } = usePoolIdByAddress(poolAddressFromUrl ?? undefined)
@@ -359,18 +363,23 @@ export function PoolPositionPage() {
         />
         {poolInfo && (
           <>
-            <BuyModal
-              isOpen={showBuyModal}
-              onDismiss={() => setShowBuyModal(false)}
-              poolInfo={poolInfo}
-              userBaseTokenBalance={userBaseTokenBalance}
-            />
-            <SellModal
-              isOpen={showSellModal}
-              onDismiss={() => setShowSellModal(false)}
-              poolInfo={poolInfo}
-              userBaseTokenBalance={userBaseTokenBalance}
-            />
+            {account && (
+              <BuyModal
+                isOpen={showBuyModal}
+                onDismiss={() => setShowBuyModal(false)}
+                poolInfo={poolInfo}
+                userBaseTokenBalance={baseTokenBalances[account]}
+              />
+            )}
+            {account && poolAddressFromUrl && (
+              <SellModal
+                isOpen={showSellModal}
+                onDismiss={() => setShowSellModal(false)}
+                poolInfo={poolInfo}
+                userBaseTokenBalance={baseTokenBalances[account]}
+                poolBaseTokenBalance={baseTokenBalances[poolAddressFromUrl]}
+              />
+            )}
             <SetLockupModal
               isOpen={showSetLockupModal}
               currentLockup={Number(minPeriod).toString()}

--- a/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/src/pages/CreatePool/PoolPositionPage.tsx
@@ -44,7 +44,7 @@ import { Link, useParams } from 'react-router-dom'
 //import { Bound } from 'state/mint/v3/actions'
 import { PoolInfo } from 'state/buy/hooks'
 //import { useTokenBalance } from 'state/connection/hooks'
-import { /*useCurrencyBalance,*/ useCurrencyBalancesMultipleAccounts } from 'state/connection/hooks'
+import { useCurrencyBalancesMultipleAccounts } from 'state/connection/hooks'
 import { usePoolIdByAddress } from 'state/governance/hooks'
 import { useFreeStakeBalance, useUnclaimedRewards } from 'state/stake/hooks'
 //import { useIsTransactionPending, useTransactionAdder } from 'state/transactions/hooks'
@@ -309,7 +309,6 @@ export function PoolPositionPage() {
     poolOwnStake: Number(poolOwnStakeFromUrl),
     irr: Number(irrFromUrl),
   } as PoolInfo
-  //const userBaseTokenBalance = useCurrencyBalance(account ?? undefined, base ?? undefined)
   const baseTokenBalances = useCurrencyBalancesMultipleAccounts(
     [account ?? undefined, poolAddressFromUrl ?? undefined],
     base ?? undefined

--- a/src/state/connection/hooks.ts
+++ b/src/state/connection/hooks.ts
@@ -1,6 +1,7 @@
 export {
   default as useCurrencyBalance,
   useCurrencyBalances,
+  useCurrencyBalancesMultipleAccounts,
   useNativeCurrencyBalances,
   useTokenBalance,
   useTokenBalances,


### PR DESCRIPTION

<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
<!-- Summary of change, including motivation and context. -->
<!-- Use verb-driven language: "Fixes XYZ" instead of "This change fixes XYZ" -->
- display error when pool does not hold enough base tokens to execute burn op
- button is disabled if pool does not hold enough
- pass additional poolBaseTokenBalance to SellModal
- create useCurrencyBalancesMultipleAccounts hook to return multiple accounts balance for the same token
- use new hook instead of useCurrencyBalance in PoolPositionPage to return additional value without making an extra RPC call

<!-- Delete inapplicable lines: -->
_Linear ticket:_
_Slack thread:_
_Relevant docs:_


<!-- Delete this section if your change does not affect UI. -->
## Screen capture

### Before
|    Mobile    |   Desktop    |
| ------------ | ------------ |
| paste_before | paste_before |


### After
|    Mobile    |   Desktop   |
| ------------ | ----------- |
| paste_after  | paste_after |


## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. 

### QA (ie manual testing)

<!-- Include steps to test the change, ensuring no regression. -->
- [ ] N/A


#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->


### Automated testing

<!-- If N/A, check and note so it is obvious to your reviewers and does not show up as an incomplete task. -->
<!-- eg - [x] Unit test N/A -->
- [ ] Unit test
- [ ] Integration/E2E test
