### PR TITLE
fix: unlock modal in vote page

### DIFF
--- a/apps/web/src/constants/tokenSafety.tsx
+++ b/apps/web/src/constants/tokenSafety.tsx
@@ -1,3 +1,4 @@
+import { GRG } from 'constants/tokens'
 import { useCurrencyInfo } from 'hooks/Tokens'
 import { Plural, Trans, t } from 'i18n'
 import { SafetyLevel } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
@@ -97,6 +98,12 @@ export const BlockedWarning: Warning = {
 
 export function useTokenWarning(tokenAddress?: string, chainId?: InterfaceChainId | number): Warning | undefined {
   const currencyInfo = useCurrencyInfo(tokenAddress, chainId)
+
+  // early return if GRG (bridged GRG may result in warning)
+  if (chainId && GRG[chainId].address === tokenAddress ) {
+    return undefined
+  }
+
   switch (currencyInfo?.safetyLevel) {
     case SafetyLevel.MediumWarning:
       return MediumWarning

--- a/apps/web/src/i18n/locales/source/en-US.json
+++ b/apps/web/src/i18n/locales/source/en-US.json
@@ -1090,7 +1090,7 @@
   "vote.votePage.details": "Details",
   "vote.votePage.execute": "Execute",
   "vote.votePage.mayBeExecutedAfter": "This proposal may be executed after {{ eta }}.",
-  "vote.votePage.onlyUniVotesBeforeBlockEligible": "Only UNI votes that were self delegated or delegated to another address before block {{ startBlock }} are eligible for voting.",
+  "vote.votePage.onlyGrgVotesBeforeDateEligible": "Only GRG votes that were atively staked before block {{ startDate }} are eligible for voting.",
   "vote.votePage.proposer": "Proposer",
   "vote.votePage.unlockVotes": "Unlock votes",
   "vote.votePage.unlockVotingLink": "{{ link }} to prepare for the next proposal.",

--- a/apps/web/src/pages/Vote/Landing.tsx
+++ b/apps/web/src/pages/Vote/Landing.tsx
@@ -17,7 +17,7 @@ import { darken } from 'polished'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button } from 'rebass/styled-components'
-import { useModalIsOpen, useToggleDelegateModal } from 'state/application/hooks'
+import { useCloseModal, useModalIsOpen, useToggleDelegateModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
 import { ProposalData, ProposalState, useAllProposalData, useUserVotes } from 'state/governance/hooks'
 import styled, { useTheme } from 'styled-components'
@@ -104,6 +104,7 @@ export default function Landing() {
 
   // toggle for showing delegation modal
   const showDelegateModal = useModalIsOpen(ApplicationModal.DELEGATE)
+  const closeModal = useCloseModal()
   const toggleDelegateModal = useToggleDelegateModal()
 
   // get data to list all proposals
@@ -120,7 +121,7 @@ export default function Landing() {
         <PageWrapper gap="lg" justify="center">
           <DelegateModal
             isOpen={showDelegateModal}
-            onDismiss={toggleDelegateModal}
+            onDismiss={closeModal}
             title={
               showUnlockVoting ? (
                 <Trans i18nKey="vote.votePage.unlockVotes" />
@@ -178,17 +179,19 @@ export default function Landing() {
                     $borderRadius="8px"
                     onClick={toggleDelegateModal}
                   >
-                    <Trans i18nKey="vote.landing.unlockVoting" />
+                    {showUnlockVoting ? (
+                      <Trans i18nKey="vote.landing.unlockVoting" />
+                    ) : availableVotes ? (
+                      <Trans
+                        i18nKey="vote.landing.voteAmount"
+                        values={{
+                          amount: <FormattedCurrencyAmount currencyAmount={availableVotes} />,
+                        }}
+                      />
+                    ) : (
+                      ''
+                    )}
                   </ButtonPrimary>
-                ) : availableVotes && JSBI.notEqual(JSBI.BigInt(0), availableVotes?.quotient) ? (
-                  <ThemedText.DeprecatedBody fontWeight={535} mr="6px">
-                    <Trans
-                      i18nKey="vote.landing.voteAmount"
-                      values={{
-                        amount: <FormattedCurrencyAmount currencyAmount={availableVotes} />,
-                      }}
-                    />
-                  </ThemedText.DeprecatedBody>
                 ) : (
                   ''
                 )}

--- a/apps/web/src/pages/Vote/VotePage.tsx
+++ b/apps/web/src/pages/Vote/VotePage.tsx
@@ -344,7 +344,7 @@ export default function VotePage() {
                 <GrayCard>
                   <ThemedText.DeprecatedBlack>
                     <Trans
-                      i18nKey="vote.votePage.onlyUniVotesBeforeBlockEligible"
+                      i18nKey="vote.votePage.onlyGrgVotesBeforeDateEligible"
                       values={{
                         startDate: startDate?.toLocaleString(locale, dateFormat),
                       }}


### PR DESCRIPTION
- prompt close unlock modal on dismiss without needed to click escape button
- correctly display original flow for unlock button where active votes are displayed when positive and move stake modal still opened
- fixed text (date instead of block)
- fix an issue which resulted in display warning on GRG on L2s