### PR TITLE
feat: upgrade implementation

### DIFF
--- a/apps/web/src/components/createPool/SellModal.tsx
+++ b/apps/web/src/components/createPool/SellModal.tsx
@@ -104,14 +104,11 @@ export default function SellModal({
 
   // it is possible that user is requesting more that its balance
   const poolHoldsEnough: boolean = useMemo(() => {
-    if (!poolBaseTokenBalance || !expectedBaseTokens || !parsedAmount || !poolInfo) {
+    if (!poolBaseTokenBalance || !expectedBaseTokens || !poolInfo) {
       return true
     }
-    if (JSBI.greaterThanOrEqual(parsedAmount.quotient, poolInfo?.userPoolBalance.quotient)) {
-      return false
-    }
     return JSBI.greaterThanOrEqual(poolBaseTokenBalance.quotient, expectedBaseTokens.quotient)
-  }, [poolBaseTokenBalance, expectedBaseTokens, parsedAmount, poolInfo])
+  }, [poolBaseTokenBalance, expectedBaseTokens, poolInfo])
 
   async function onSell(): Promise<void | undefined> {
     setAttempting(true)

--- a/apps/web/src/components/createPool/UpgradeModal.tsx
+++ b/apps/web/src/components/createPool/UpgradeModal.tsx
@@ -94,7 +94,7 @@ export default function UpgradeModal({ isOpen, implementation, onDismiss, title 
         <LoadingView onDismiss={wrappedOnDismiss}>
           <AutoColumn gap="12px" justify="center">
             <ThemedText.DeprecatedLargeHeader>
-              <Trans>Upgrading Implementation to {implementation}</Trans>
+              <Trans>Upgrading Implementation</Trans>
             </ThemedText.DeprecatedLargeHeader>
           </AutoColumn>
         </LoadingView>

--- a/apps/web/src/components/createPool/UpgradeModal.tsx
+++ b/apps/web/src/components/createPool/UpgradeModal.tsx
@@ -1,0 +1,136 @@
+import { parseUnits } from '@ethersproject/units'
+import { Trans } from 'react-i18next'
+import JSBI from 'jsbi'
+import { ReactNode, useCallback, useState } from 'react'
+import { X } from 'react-feather'
+import styled from 'lib/styled-components'
+import { ThemedText } from 'theme/components/text'
+import { TransactionStatus } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
+import { ModalName} from 'uniswap/src/features/telemetry/constants'
+import { logger } from 'utilities/src/logger/logger'
+
+import { useUpgradeCallback } from 'state/pool/hooks'
+import { useIsTransactionConfirmed, useTransaction } from 'state/transactions/hooks'
+import { ButtonError } from 'components/Button/buttons'
+import { AutoColumn } from 'components/deprecated/Column'
+import { RowBetween } from 'components/deprecated/Row'
+import { Modal } from 'uniswap/src/components/modals/Modal'
+import { LoadingView, SubmittedView } from 'components/ModalViews'
+import NameInputPanel from 'components/NameInputPanel'
+import { useAccount } from 'hooks/useAccount'
+
+const ContentWrapper = styled(AutoColumn)`
+  width: 100%;
+  padding: 24px;
+`
+
+const StyledClosed = styled(X)`
+  :hover {
+    cursor: pointer;
+  }
+`
+
+interface UpgradeModalProps {
+  isOpen: boolean
+  implementation: string
+  onDismiss: () => void
+  title: ReactNode
+}
+
+export default function UpgradeModal({ isOpen, implementation, onDismiss, title }: UpgradeModalProps) {
+  const account = useAccount()
+
+  const upgradeCallback = useUpgradeCallback()
+
+  // monitor call to help UI loading state
+  const [hash, setHash] = useState<string | undefined>()
+  const [attempting, setAttempting] = useState(false)
+
+  const transaction = useTransaction(hash)
+  const confirmed = useIsTransactionConfirmed(hash)
+  const transactionSuccess = transaction?.status === TransactionStatus.Confirmed
+
+  // wrapper to reset state on modal close
+  function wrappedOnDismiss() {
+    setHash(undefined)
+    setAttempting(false)
+    onDismiss()
+  }
+
+  async function onUpgrade() {
+    setAttempting(true)
+
+    // if callback not returned properly ignore
+    if (!account.address || !account.chainId || !upgradeCallback) {
+      return
+    }
+
+    // try set spread and store hash
+    const hash = await upgradeCallback()?.catch((error) => {
+      setAttempting(false)
+      logger.info('UpgradeModal', 'onUpgrade', error)
+    })
+
+    if (hash) {
+      setHash(hash)
+    }
+  }
+
+  return (
+    <Modal name={ModalName.DappRequest} isModalOpen={isOpen} isDismissible onClose={wrappedOnDismiss} maxHeight={480}>
+      {!attempting && !hash && (
+        <ContentWrapper gap="lg">
+          <AutoColumn gap="lg" justify="center">
+            <RowBetween>
+              <ThemedText.DeprecatedMediumHeader fontWeight={500}>{title}</ThemedText.DeprecatedMediumHeader>
+              <StyledClosed stroke="black" onClick={wrappedOnDismiss} />
+            </RowBetween>
+            <ButtonError onClick={onUpgrade} disabled={!implementation}>
+              <ThemedText.DeprecatedMediumHeader color="white">
+                <Trans>Upgrade Implementation to {implementation}</Trans>
+              </ThemedText.DeprecatedMediumHeader>
+            </ButtonError>
+          </AutoColumn>
+        </ContentWrapper>
+      )}
+      {attempting && !hash && (
+        <LoadingView onDismiss={wrappedOnDismiss}>
+          <AutoColumn gap="12px" justify="center">
+            <ThemedText.DeprecatedLargeHeader>
+              <Trans>Upgrading Implementation to {implementation}</Trans>
+            </ThemedText.DeprecatedLargeHeader>
+          </AutoColumn>
+        </LoadingView>
+      )}
+      {hash && (
+        <SubmittedView onDismiss={wrappedOnDismiss} hash={hash} transactionSuccess={transactionSuccess}>
+          <AutoColumn gap="12px" justify="center">
+            {!confirmed ? (
+              <>
+                <ThemedText.DeprecatedLargeHeader>
+                  <Trans>Transaction Submitted</Trans>
+                </ThemedText.DeprecatedLargeHeader>
+                <ThemedText.DeprecatedBody fontSize={20}>
+                  <Trans>Upgrading implementation to {implementation}</Trans>
+                </ThemedText.DeprecatedBody>
+              </>
+            ) : transactionSuccess ? (
+              <>
+                <ThemedText.DeprecatedLargeHeader>
+                  <Trans>Transaction Success</Trans>
+                </ThemedText.DeprecatedLargeHeader>
+                <ThemedText.DeprecatedBody fontSize={20}>
+                  <Trans>Implementation Upgraded to {implementation}</Trans>
+                </ThemedText.DeprecatedBody>
+              </>
+            ) : (
+              <ThemedText.DeprecatedLargeHeader>
+                <Trans>Transaction Failed</Trans>
+              </ThemedText.DeprecatedLargeHeader>
+            )}
+          </AutoColumn>
+        </SubmittedView>
+      )}
+    </Modal>
+  )
+}

--- a/apps/web/src/components/createPool/UpgradeModal.tsx
+++ b/apps/web/src/components/createPool/UpgradeModal.tsx
@@ -1,7 +1,5 @@
-import { parseUnits } from '@ethersproject/units'
 import { Trans } from 'react-i18next'
-import JSBI from 'jsbi'
-import { ReactNode, useCallback, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { X } from 'react-feather'
 import styled from 'lib/styled-components'
 import { ThemedText } from 'theme/components/text'
@@ -16,7 +14,6 @@ import { AutoColumn } from 'components/deprecated/Column'
 import { RowBetween } from 'components/deprecated/Row'
 import { Modal } from 'uniswap/src/components/modals/Modal'
 import { LoadingView, SubmittedView } from 'components/ModalViews'
-import NameInputPanel from 'components/NameInputPanel'
 import { useAccount } from 'hooks/useAccount'
 
 const ContentWrapper = styled(AutoColumn)`
@@ -87,7 +84,7 @@ export default function UpgradeModal({ isOpen, implementation, onDismiss, title 
             </RowBetween>
             <ButtonError onClick={onUpgrade} disabled={!implementation}>
               <ThemedText.DeprecatedMediumHeader color="white">
-                <Trans>Upgrade Implementation to {implementation}</Trans>
+                <Trans>Upgrade Implementation</Trans>
               </ThemedText.DeprecatedMediumHeader>
             </ButtonError>
           </AutoColumn>
@@ -111,7 +108,7 @@ export default function UpgradeModal({ isOpen, implementation, onDismiss, title 
                   <Trans>Transaction Submitted</Trans>
                 </ThemedText.DeprecatedLargeHeader>
                 <ThemedText.DeprecatedBody fontSize={20}>
-                  <Trans>Upgrading implementation to {implementation}</Trans>
+                  <Trans>Upgrading implementation</Trans>
                 </ThemedText.DeprecatedBody>
               </>
             ) : transactionSuccess ? (
@@ -120,7 +117,7 @@ export default function UpgradeModal({ isOpen, implementation, onDismiss, title 
                   <Trans>Transaction Success</Trans>
                 </ThemedText.DeprecatedLargeHeader>
                 <ThemedText.DeprecatedBody fontSize={20}>
-                  <Trans>Implementation Upgraded to {implementation}</Trans>
+                  <Trans>Implementation Upgraded</Trans>
                 </ThemedText.DeprecatedBody>
               </>
             ) : (

--- a/apps/web/src/hooks/useSmartPools.ts
+++ b/apps/web/src/hooks/useSmartPools.ts
@@ -38,7 +38,7 @@ export interface UserAccount {
 
 export function useImplementation(poolAddress: string | undefined, implementationSlot: string): [string, string] | undefined {
   const poolExtendedContract = usePoolExtendedContract(poolAddress)
-  const currentImplementation = useSingleCallResult(poolExtendedContract ?? undefined, 'getStorageSlotsAt', [implementationSlot]).result?.[0]
+  const currentImplementation = useSingleCallResult(poolExtendedContract ?? undefined, 'getStorageAt', [implementationSlot, 1]).result?.[0]
   const poolFactory = usePoolFactoryContract()
   const beaconImplementation = useSingleCallResult(poolFactory ?? undefined, 'implementation').result?.[0]
 
@@ -47,7 +47,7 @@ export function useImplementation(poolAddress: string | undefined, implementatio
     if (!currentImplementation || !beaconImplementation) {
       return undefined
     }
-    return [currentImplementation, beaconImplementation]
+    return ["0x" + currentImplementation.slice(-40), beaconImplementation]
   }, [currentImplementation, beaconImplementation])
 }
 

--- a/apps/web/src/hooks/useSmartPools.ts
+++ b/apps/web/src/hooks/useSmartPools.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { useSingleCallResult } from 'lib/hooks/multicall'
 import { useMemo } from 'react'
 // TODO: remove duplicate method definition and reorg code
-import { usePoolExtendedContract } from 'state/pool/hooks'
+import { usePoolExtendedContract, usePoolFactoryContract } from 'state/pool/hooks'
 
 interface PoolInitParams {
   name: string
@@ -34,6 +34,21 @@ interface PoolDetails {
 export interface UserAccount {
   userBalance: BigNumber
   activation: BigNumber
+}
+
+export function useImplementation(poolAddress: string | undefined, implementationSlot: string): [string, string] | undefined {
+  const poolExtendedContract = usePoolExtendedContract(poolAddress)
+  const currentImplementation = useSingleCallResult(poolExtendedContract ?? undefined, 'getStorageSlotsAt', [implementationSlot]).result?.[0]
+  const poolFactory = usePoolFactoryContract()
+  const beaconImplementation = useSingleCallResult(poolFactory ?? undefined, 'implementation').result?.[0]
+
+  // TODO: verify if memoization is needed here
+  return useMemo(() => {
+    if (!currentImplementation || !beaconImplementation) {
+      return undefined
+    }
+    return [currentImplementation, beaconImplementation]
+  }, [currentImplementation, beaconImplementation])
 }
 
 export function useSmartPoolFromAddress(poolAddress: string | undefined): PoolDetails | undefined {

--- a/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
@@ -324,7 +324,6 @@ export default function PoolPositionPage() {
   // Check if the pool needs an upgrade
   const [currentImplementation, beaconImplementation] = useImplementation(poolAddressFromUrl ?? undefined, IMPLEMENTATION_SLOT) ?? [undefined, undefined]
 
-  // TODO: after debugging, restrict to pool operator only, plus try to wrap onchain calls when caller is pool operator to save on rpc calls
   const needsUpgrade = useMemo(() => {
     return currentImplementation && beaconImplementation && currentImplementation.toLowerCase() !== beaconImplementation.toLowerCase()
   }, [currentImplementation, beaconImplementation])
@@ -468,7 +467,7 @@ export default function PoolPositionPage() {
                     </HoverText>
                   </Link>
                 )}
-                {needsUpgrade && (
+                {needsUpgrade && owner === account.address && (
                   <ResponsiveButtonPrimary
                     style={{ marginRight: '8px' }}
                     width="fit-content"

--- a/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
@@ -15,6 +15,7 @@ import SellModal from 'components/createPool/SellModal'
 import SetLockupModal from 'components/createPool/SetLockupModal'
 import SetSpreadModal from 'components/createPool/SetSpreadModal'
 import SetValueModal from 'components/createPool/SetValueModal'
+import UpgradeModal from 'components/createPool/UpgradeModal'
 import Row, { RowBetween, RowFixed } from 'components/deprecated/Row'
 import HarvestYieldModal from 'components/earn/HarvestYieldModal'
 import MoveStakeModal from 'components/earn/MoveStakeModal'
@@ -28,7 +29,7 @@ import DelegateModal from 'components/vote/DelegateModal'
 import { /*BIG_INT_ZERO,*/ ZERO_ADDRESS } from 'constants/misc'
 import { useCurrency } from 'hooks/Tokens'
 import { useAccount } from 'hooks/useAccount'
-import { UserAccount, useSmartPoolFromAddress, useUserPoolBalance } from 'hooks/useSmartPools'
+import { UserAccount, useImplementation, useSmartPoolFromAddress, useUserPoolBalance } from 'hooks/useSmartPools'
 // TODO: this import is from node modules
 import JSBI from 'jsbi'
 //import { PoolState, usePool } from 'hooks/usePools'
@@ -242,8 +243,10 @@ export default function PoolPositionPage() {
   }>()
   const account = useAccount()
   //const theme = useTheme()
+  const IMPLEMENTATION_SLOT = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
 
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false) // State for upgrade modal
 
   const [showBuyModal, setShowBuyModal] = useState(false)
   const [showSellModal, setShowSellModal] = useState(false)
@@ -318,6 +321,14 @@ export default function PoolPositionPage() {
   const freeStakeBalance = useFreeStakeBalance()
   const hasFreeStake = JSBI.greaterThan(freeStakeBalance ? freeStakeBalance.quotient : JSBI.BigInt(0), JSBI.BigInt(0))
 
+  // Check if the pool needs an upgrade
+  const [currentImplementation, beaconImplementation] = useImplementation(poolAddressFromUrl ?? undefined, IMPLEMENTATION_SLOT) ?? [undefined, undefined]
+
+  // TODO: after debugging, restrict to pool operator only, plus try to wrap onchain calls when caller is pool operator to save on rpc calls
+  const needsUpgrade = useMemo(() => {
+    return currentImplementation && beaconImplementation && currentImplementation !== beaconImplementation
+  }, [currentImplementation, beaconImplementation])
+
   const handleMoveStakeClick = useCallback(() => {
     setShowMoveStakeModal(true)
     if (deactivate) {
@@ -328,6 +339,10 @@ export default function PoolPositionPage() {
   const handleDeactivateStakeClick = useCallback(() => {
     setShowMoveStakeModal(true)
     setDeactivate(true)
+  }, [])
+
+  const handleUpgradeClick = useCallback(() => {
+    setShowUpgradeModal(true)
   }, [])
 
   function modalHeader() {
@@ -398,6 +413,14 @@ export default function PoolPositionPage() {
                 title={<Trans>Set Value</Trans>}
               />
             )}
+            {needsUpgrade && beaconImplementation && (
+              <UpgradeModal 
+                isOpen={showUpgradeModal}
+                onDismiss={() => setShowUpgradeModal(false)}
+                implementation={beaconImplementation}
+                title={<Trans>Upgrade Implementation</Trans>}
+              />
+            )}
             <DelegateModal
               isOpen={showStakeModal}
               poolInfo={poolInfo}
@@ -444,6 +467,17 @@ export default function PoolPositionPage() {
                       <Trans>← Back to Pools</Trans>
                     </HoverText>
                   </Link>
+                )}
+                {needsUpgrade && (
+                  <ResponsiveButtonPrimary
+                    style={{ marginRight: '8px' }}
+                    width="fit-content"
+                    padding="6px 8px"
+                    $borderRadius="12px"
+                    onClick={handleUpgradeClick}
+                  >
+                    <Trans>Upgrade</Trans>
+                  </ResponsiveButtonPrimary>
                 )}
                 {unclaimedRewards && unclaimedRewards[0]?.yieldAmount && (
                   <ResponsiveButtonPrimary

--- a/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
+++ b/apps/web/src/pages/CreatePool/PoolPositionPage.tsx
@@ -326,7 +326,7 @@ export default function PoolPositionPage() {
 
   // TODO: after debugging, restrict to pool operator only, plus try to wrap onchain calls when caller is pool operator to save on rpc calls
   const needsUpgrade = useMemo(() => {
-    return currentImplementation && beaconImplementation && currentImplementation !== beaconImplementation
+    return currentImplementation && beaconImplementation && currentImplementation.toLowerCase() !== beaconImplementation.toLowerCase()
   }, [currentImplementation, beaconImplementation])
 
   const handleMoveStakeClick = useCallback(() => {

--- a/apps/web/src/state/transactions/types.ts
+++ b/apps/web/src/state/transactions/types.ts
@@ -41,6 +41,7 @@ export enum TransactionType {
   BRIDGE = 33,
   CREATE_POSITION = 34,
   MIGRATE_LIQUIDITY_V3_TO_V4 = 35,
+  UPGRADE_IMPLEMENTATION = 36,
 }
 interface BaseTransactionInfo {
   type: TransactionType
@@ -247,6 +248,14 @@ export interface SetSmartPoolValuePoolTransactionInfo {
   type: TransactionType.SET_VALUE
 }
 
+export interface UpgradeImplementationTransactionInfo {
+  type: TransactionType.UPGRADE_IMPLEMENTATION
+  //currentImplementation: number
+  //newImplementation: number
+  //contractAddress: string
+  //chainId: UniverseChainId
+}
+
 export type TransactionInfo =
   | ApproveTransactionInfo
   | ExactOutputSwapTransactionInfo
@@ -277,6 +286,7 @@ export type TransactionInfo =
   | BridgeTransactionInfo
   | CreatePositionTransactionInfo
   | MigrateV3LiquidityToV4TransactionInfo
+  | UpgradeImplementationTransactionInfo
 
 interface BaseTransactionDetails {
   status: TransactionStatus


### PR DESCRIPTION
- implement upgrade implementation button + modal in pool position page, to prompt pool operator to upgrade whenever a new implementation is stored in the beacon
- fixed an issue which prevented selling all user owned pool tokens but 1 unit on burn max
- return an error on mint if token amount is below 0.001 (the protocol minimum in token units), which resulted in the buy modal being stuck on loading without returning an error